### PR TITLE
Add buildSeeAlso method.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -41,6 +41,7 @@ class IIIF {
         $manifest['provider'] = self::buildProvider();
         $manifest['thumbnail'] = self::buildThumbnail(200, 200);
         $manifest['items'] = self::buildItems($id);
+        $manifest['seeAlso'] = self::buildSeeAlso();
 
         if ($this->type === 'Book') {
             $manifest['behavior'] = ["paged"];
@@ -145,6 +146,24 @@ class IIIF {
             ]
         ];
 
+    }
+
+    private function buildSeeAlso () {
+
+        return [
+            (object) [
+                "id" => $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/MODS' ,
+                "type" => "Dataset",
+                "label" => [ 
+                    (object) [
+                        "en" =>
+                        [ "Bibliographic Description in MODS" ] 
+                    ],
+                    "format" => "application/xml",
+                    "profile" => "http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"
+                ]
+            ]
+        ];
     }
 
     public function buildThumbnail ($width, $height) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -156,13 +156,12 @@ class IIIF {
                 "type" => "Dataset",
                 "label" => [ 
                     (object) [
-                        "en" =>
-                        [ "Bibliographic Description in MODS" ] 
-                    ],
-                    "format" => "application/xml",
-                    "profile" => "http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"
+                        "en" => [ "Bibliographic Description in MODS" ]
+                    ]
+                ],
+                "format" => "application/xml",
+                "profile" => "http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"
                 ]
-            ]
         ];
     }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -154,11 +154,11 @@ class IIIF {
             (object) [
                 "id" => $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/MODS' ,
                 "type" => "Dataset",
-                "label" => [ 
+                "label" =>
                     (object) [
                         "en" => [ "Bibliographic Description in MODS" ]
                     ]
-                ],
+                ,
                 "format" => "application/xml",
                 "profile" => "http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"
                 ]


### PR DESCRIPTION
## What Does This Do

This adds a `seeAlso` property to the presentation manifest according to [prez v3](https://iiif.io/api/presentation/3.0/#seealso). 

## Some creative liberties taken

I assumed that private methods in PHP are similar to private methods in other languages I know and that private methods are available to the instance of the class but not external to the class.  Since I have no idea why this would need to be open external to the class, I made it private although this seems to differ from other methods in the class.  If I've misunderstood this, things may not work.

## So, did you test this?

I did not.  I read the README, but I felt like there was something I was missing.

## And you did this why?

I'm rexploring change discovery and thinking about a presentation for next week.  While rereading the specifications, I remembered that applications that consume IIIF manifests and change discovery collections that reference manfiests should use the descriptive metadata referenced by the seeAlso reference of the presentation manifest.  I'm thinking about writing a sample change discovery app around our data this weekend, and since we use this app for building our manifests, I thought we should add this.