### PR TITLE
Switch role term label and add additional check.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -58,7 +58,7 @@ class IIIF {
         $metadata = array(
             'Alternative Title' => $this->xpath->query('titleInfo[@type="alternative"]'),
             'Table of Contents' => $this->xpath->query('tableOfContents'),
-            'Role Term' => $this->xpath->query('name/namePart'),
+            'Creators and Contributors' => $this->xpath->query('name/namePart'),
             'Publisher' => $this->xpath->query('originInfo/publisher'),
             'Date' => $this->xpath->query('originInfo/dateCreated|originInfo/dateOther'),
             'Publication Date' => $this->xpath->query('originInfo/dateIssued'),
@@ -79,7 +79,7 @@ class IIIF {
         $sets = array();
 
         foreach ($array as $label => $value) :
-            if ($value !== null) :
+            if ($value !== null or empty($value) !== true) :
                 $sets[] = self::getLabelValuePair(
                     $label,
                     $value


### PR DESCRIPTION
## What Does This Do

Changes label from "Role Term" to  "Creators and Contributors" and attempts to stop key value pairs with empty arrays from getting into manifests.

## About the Label Change

The original plan was grab all `//mods/name` values and associate them base on the value of `role/roleTerm`.  The value of `role/roleTerm` would be the label and the value of `namePart` would be represented in the value.  This doesn't attempt to do this, but instead simply switches the label to Creators and Contributors.  We can revisit this later if necessary.

## About the Empty Array

Currently, empty arrays are getting into the final manifest even thought validateMetadata() attempts to stop this.  This change attempts to fix this.  An example is [tenncities:343](https://digital.lib.utk.edu/assemble/manifest/tenncities/343).

## Have you tested this?

No, I still can't get the dev environment running locally.

