### PR TITLE
Generate IIIF Collections (Presentation 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 
 # IIIF Assemble
 
-This app WILL assemble and serve a IIIF Presentation API 3.0 manifest from a Fedora 3.8 object with a MODS datastream. The routing follows a pattern of `/assemble/manifest/{namepsace}/{id}` where `namespace` is a string and `id` is positive integer.
 
-<img src="https://digital.lib.utk.edu/iiif/2/collections~islandora~object~tenncities%3A343~datastream~OBJ/full/!200,200/0/default.jpg" alt="Cabin near Knoxville" />
+<img src="https://digital.lib.utk.edu/iiif/2/collections~islandora~object~tenncities%3A343~datastream~OBJ/full/!400,400/0/default.jpg" alt="Cabin near Knoxville" />
+
+This app assembles and serves IIIF Presentation API 3.0 Manifest and Collections from a Fedora 3.8 objects with a MODS datastream. 
+
+Where `namespace` is a string and `id` is positive integer:
+
+- **Manifest**: `/assemble/manifest/{namespace}/{id}` 
+- **Collection**: ```/assemble/collection/{namespace}/{id}```
+
+## Manifest
 
 The example route of `/assemble/manifest/tenncities/343` will correlate to **tenncities:343**, ex: https://digital.lib.utk.edu/assemble/manifest/tenncities/343
+
+## Collection
+
+The path for a collection with the PID `gsmrc:thompson` would be `/assemble/collection/gsmrc/thompson`, ex: https://digital.lib.utk.edu/assemble/collection/gsmrc/thompson. Embedded collections are currently not supported.
+
 
 ## Notes and To Dos
 
@@ -16,7 +29,7 @@ Note: This is not production ready.
 - This only outputs manifests and metadata fields mapped for boutique purposes.
 - This is not currently intended as an access tool for all UT Libraries' collections in the wild.
 - This currently does not create collection lists of multiple manifests.
-- This generator caches a manifest for 24 Hours. If metadata or OBJ datastreams are updated, the directory for the manifest must be cleared at `./cache/namespace/id`
+- This generator caches a manifest for 180 days. If metadata or OBJ datastreams are updated, the directory for the manifest must be cleared at `./cache/namespace/id`
 
 ### To Do
 - Though possible at some point, this generator has no current way creating a manifest with referenced annotation lists.

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -51,24 +51,24 @@ class Collection
     {
 
         $persistentIdentifier = implode('%3A', $this->persistentIdentifier);
-
         $object = Request::getObjects($persistentIdentifier);
-        $items = Request::getObjects($persistentIdentifier, 'XML', true);
 
         if ($object['status'] === 200) :
             $model = simplexml_load_string($object['body'])->objModels->model;
             if (self::isCollection($model)) :
+                $items = Request::getCollectionItems($persistentIdentifier, 'csv');
                 $mods = Request::getDatastream('MODS', $persistentIdentifier);
-                $iiif = new IIIF($persistentIdentifier, $mods['body'], $items);
-                $collection = $iiif->buildCollection();
-                self::cacheCollection($collection);
-                return $collection;
+                $collection = Utility::orderCollection($items['body']);
+                $iiif = new IIIF($persistentIdentifier, $mods['body'], $collection, "info:fedora/islandora:collectionCModel");
+                $iiifCollection = $iiif->buildCollection();
+                self::cacheCollection($iiifCollection);
+                return $iiifCollection;
             else :
                 $object['body'] = 'Object ' . str_replace('%3A', ':', $persistentIdentifier) . ' is not of object model islandora:collectionCModel.';
                 return json_encode($object);
             endif;
         else :
-            return json_encode($object);
+            return json_encode($items);
         endif;
 
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -43,14 +43,14 @@ class Collection
         if (self::collectionAvailable()) {
             $collection = self::getCollection();
         } else {
-            $collection = self::buildCollection();
+            $collection = self::newCollection();
         }
 
         return $collection;
 
     }
 
-    private function buildCollection ()
+    private function newCollection ()
     {
 
         $persistentIdentifier = implode('%3A', $this->persistentIdentifier);

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -54,13 +54,15 @@ class Collection
     {
 
         $persistentIdentifier = implode('%3A', $this->persistentIdentifier);
+
         $object = Request::getObjects($persistentIdentifier);
+        $items = Request::getObjects($persistentIdentifier, 'XML', true);
 
         if ($object['status'] === 200) :
             $model = simplexml_load_string($object['body'])->objModels->model;
             if (self::isCollection($model)) :
                 $mods = Request::getDatastream('MODS', $persistentIdentifier);
-                $iiif = new IIIF($persistentIdentifier, $mods['body'], $object);
+                $iiif = new IIIF($persistentIdentifier, $mods['body'], $items);
                 $collection = $iiif->buildCollection();
                 self::cacheCollection($collection);
                 return $collection;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -90,7 +90,7 @@ class Collection
     {
 
         $namespace = self::getNamespacePath();
-        $filename = self::getCollectionPath($namespace) . '/manifest.json';
+        $filename = self::getCollectionPath($namespace) . '/collection.json';
         $expires = 15552000;
 
         if (isset($_GET['update']) && $_GET['update'] === '1') {
@@ -111,7 +111,7 @@ class Collection
     {
 
         $namespace = self::getNamespacePath();
-        $filename = self::getCollectionPath($namespace) . '/manifest.json';
+        $filename = self::getCollectionPath($namespace) . '/collection.json';
 
         return file_get_contents($filename);
 
@@ -130,7 +130,7 @@ class Collection
             mkdir($id);
         }
 
-        $path = $id . '/manifest.json';
+        $path = $id . '/collection.json';
 
         file_put_contents($path, $manifest);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -59,7 +59,7 @@ class Collection
                 $items = Request::getCollectionItems($persistentIdentifier, 'csv');
                 $mods = Request::getDatastream('MODS', $persistentIdentifier);
                 $collection = Utility::orderCollection($items['body']);
-                $iiif = new IIIF($persistentIdentifier, $mods['body'], $collection, "info:fedora/islandora:collectionCModel");
+                $iiif = new IIIF($persistentIdentifier, $mods['body'], $collection, $model);
                 $iiifCollection = $iiif->buildCollection();
                 self::cacheCollection($iiifCollection);
                 return $iiifCollection;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -9,15 +9,12 @@ class Collection
 
     private $requestMethod;
     private $persistentIdentifier;
-    private $url;
 
     public function __construct($requestMethod, $persistentIdentifier)
     {
 
         $this->requestMethod = $requestMethod;
         $this->persistentIdentifier = $persistentIdentifier;
-
-        $this->url = Utility::getBaseUrl();
 
     }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -42,7 +42,7 @@ class IIIF {
 
     }
 
-    public function buildPresentation ()
+    public function buildManifest ()
     {
         $id = $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]);
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -51,7 +51,9 @@ class IIIF {
             $items[] = (object) [
                 'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item),
                 'type' => 'Manifest',
-                'label' => $item
+                'label' => (object) [
+                    'none' => [$item]
+                    ]
             ];
         }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -9,6 +9,7 @@ class IIIF {
 
     private $pid;
     private $xpath;
+    private $object;
     private $type;
     private $url;
 
@@ -19,6 +20,7 @@ class IIIF {
 
         $this->pid = $pid;
         $this->mods = $mods;
+        $this->object = $object;
         $this->xpath = new XPath($mods);
         $this->type = self::determineTypeByModel($model);
 
@@ -494,7 +496,18 @@ class IIIF {
 
     public function buildCollectionsItems () {
 
-        return null;
+        $xpath = new XPath($this->object['body']);
+        $items = [];
+
+        foreach ($xpath->query('resultList/objectFields/pid') as $item) {
+            $items[] = (object) [
+                'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item),
+                'type' => 'Manifest',
+                'label' => $item
+            ];
+        }
+
+        return $items;
 
     }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -42,6 +42,23 @@ class IIIF {
 
     }
 
+    private function buildCollectionsItems () {
+
+        $xpath = new XPath($this->object['body']);
+        $items = [];
+
+        foreach ($xpath->query('resultList/objectFields/pid') as $item) {
+            $items[] = (object) [
+                'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item),
+                'type' => 'Manifest',
+                'label' => $item
+            ];
+        }
+
+        return $items;
+
+    }
+
     public function buildManifest ()
     {
         $id = $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]);
@@ -492,23 +509,6 @@ class IIIF {
 
     private static function getDuration () {
         return 500;
-    }
-
-    public function buildCollectionsItems () {
-
-        $xpath = new XPath($this->object['body']);
-        $items = [];
-
-        foreach ($xpath->query('resultList/objectFields/pid') as $item) {
-            $items[] = (object) [
-                'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item),
-                'type' => 'Manifest',
-                'label' => $item
-            ];
-        }
-
-        return $items;
-
     }
 
     private static function determineTypeByModel ($islandoraModel) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -36,13 +36,13 @@ class IIIF {
         $collection['id'] = $id;
         $collection['type'] = 'Collection';
         $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
-        $collection['items'] = self::buildCollectionsItems();
+        $collection['items'] = self::buildCollectionItems();
 
         return json_encode($collection);
 
     }
 
-    private function buildCollectionsItems () {
+    private function buildCollectionItems () {
 
         $xpath = new XPath($this->object['body']);
         $items = [];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -13,10 +13,12 @@ class IIIF {
     private $type;
     private $url;
 
-    public function __construct($pid, $mods, $object)
+    public function __construct($pid, $mods, $object, $model = null)
     {
 
-        $model = simplexml_load_string($object['body'])->objModels->model;
+        if (!$model) {
+            $model = simplexml_load_string($object['body'])->objModels->model;
+        }
 
         $this->pid = $pid;
         $this->mods = $mods;
@@ -42,12 +44,9 @@ class IIIF {
 
     }
 
-    private function buildCollectionItems () {
+    private function buildCollectionItems ($items = []) {
 
-        $xpath = new XPath($this->object['body']);
-        $items = [];
-
-        foreach ($xpath->query('resultList/objectFields/pid') as $item) {
+        foreach ($this->object as $item) {
             $items[] = (object) [
                 'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item),
                 'type' => 'Manifest',

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -26,6 +26,20 @@ class IIIF {
 
     }
 
+    public function buildCollection ()
+    {
+        $id = $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]);
+
+        $collection['@context'] = ['https://iiif.io/api/presentation/3/context.json'];
+        $collection['id'] = $id;
+        $collection['type'] = 'Collection';
+        $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
+        $collection['items'] = self::buildCollectionsItems();
+
+        return json_encode($collection);
+
+    }
+
     public function buildPresentation ()
     {
         $id = $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]);
@@ -476,6 +490,12 @@ class IIIF {
 
     private static function getDuration () {
         return 500;
+    }
+
+    public function buildCollectionsItems () {
+
+        return null;
+
     }
 
     private static function determineTypeByModel ($islandoraModel) {

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -39,14 +39,14 @@ class Manifest
         if (self::manifestAvailable()) {
             $manifest = self::getManifest();
         } else {
-            $manifest = self::buildManifest();
+            $manifest = self::newManifest();
         }
 
         return $manifest;
 
     }
 
-    private function buildManifest()
+    private function newManifest()
     {
 
         $persistentIdentifier = implode('%3A', $this->persistentIdentifier);
@@ -60,7 +60,7 @@ class Manifest
 
         if ($mods['status'] === 200) :
             $iiif = new IIIF($persistentIdentifier, $mods['body'], $object);
-            $presentation = $iiif->buildPresentation();
+            $presentation = $iiif->buildManifest();
             self::cacheManifest($presentation);
             return $presentation;
         else :

--- a/src/Request.php
+++ b/src/Request.php
@@ -81,6 +81,21 @@ class Request {
 
     }
 
+    public static function getCollectionItems($pid, $format = 'csv') {
+
+        $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';
+
+        $query = "PREFIX fedora-model: <info:fedora/fedora-system:def/model#> PREFIX fedora-rels-ext: ";
+        $query .= "<info:fedora/fedora-system:def/relations-external#> PREFIX isl-rels-ext: ";
+        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$item FROM <#ri> WHERE {{ \$item ";
+        $query .= "fedora-rels-ext:isMemberOfCollection <info:fedora/" . $pid ."> .}}";
+
+        $request .= self::escapeQuery($query);
+
+        return self::curlRequest($request);
+
+    }
+
     public static function getDatastream ($dsid, $pid, $format = 'XML') {
 
         $request = $_ENV['FEDORA_URL'] . '/objects/' . $pid;

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -76,6 +76,22 @@ class Utility {
 
     }
 
+    public static function orderCollection ($csv)
+    {
+
+        $result = str_getcsv($csv, "\n");
+        unset($result[0]);
+
+        $index = [];
+
+        foreach ($result as $string) {
+            $item = explode(',', $string);
+            $index[] = str_replace('info:fedora/', '', $item[0]);
+        }
+
+        return $index;
+
+    }
 
 }
 


### PR DESCRIPTION
Addresses https://jirautk.atlassian.net/browse/DIGITAL-1130

## What Does This Do

This adds a Collection class to the assemble application, allowing for creation of on the fly collections according to the[Presentation 3.0 API](https://iiif.io/api/presentation/3.0/#51-collectioncollections). 

## Minimal approach
Because these collections are not yet intended to be shared publicly, I approached this to only meet the MUSTs of specification. In addition, I limited the `label` of each collection item to the PID returned from RISearch. Retrieval of the actual title of each object as the label would require an additional API request for each item.

## So, did you test this?

If you have the [utk_digital](https://github.com/utkdigitalinitiatives/utk_digital) Vagrant running locally, resolve to a URL where the pattern of the collection PID is `/assemble/collection/{namespace}/{id}`. For example if the collection is **collections:rfta**, the URL would be http://localhost:8000/assemble/collection/collections/rfta.