### PR TITLE
Set Sound/Video type to proxy dsid URI.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -398,10 +398,10 @@ class IIIF {
 
         if (in_array($this->type, ['Image', 'Book'])) :
             $iiifImage = self::getIIIFImageURI('JP2', $pid);
-            $item = self::getItemBody($iiifImage, $datastream . '/OBJ');
+            $item = self::getItemBody($iiifImage, $datastream . 'OBJ');
 
         elseif ($this->type === 'Sound') :
-            $item['id'] = $datastream . '/PROXY_MP3';
+            $item['id'] = $datastream . 'PROXY_MP3';
             $item['type'] = "Sound";
             $item['width'] = 640;
             $item['height'] = 360;
@@ -409,7 +409,7 @@ class IIIF {
             $item['format'] = "audio/mpeg";
 
         elseif ($this->type === 'Video') :
-            $item['id'] = $datastream . '/MP4';
+            $item['id'] = $datastream . 'MP4';
             $item['type'] = "Video";
             $item['width'] = 640;
             $item['height'] = 360;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -394,14 +394,14 @@ class IIIF {
 
         $item = array();
 
-        $datastream = $this->url . '/collections/islandora/object/' . $pid . '/datastream/OBJ';
+        $datastream = $this->url . '/collections/islandora/object/' . $pid . '/datastream/';
 
         if (in_array($this->type, ['Image', 'Book'])) :
             $iiifImage = self::getIIIFImageURI('JP2', $pid);
-            $item = self::getItemBody($iiifImage, $datastream);
+            $item = self::getItemBody($iiifImage, $datastream . '/OBJ');
 
         elseif ($this->type === 'Sound') :
-            $item['id'] = $datastream;
+            $item['id'] = $datastream . '/PROXY_MP3';
             $item['type'] = "Sound";
             $item['width'] = 640;
             $item['height'] = 360;
@@ -409,7 +409,7 @@ class IIIF {
             $item['format'] = "audio/mpeg";
 
         elseif ($this->type === 'Video') :
-            $item['id'] = $datastream;
+            $item['id'] = $datastream . '/MP4';
             $item['type'] = "Video";
             $item['width'] = 640;
             $item['height'] = 360;


### PR DESCRIPTION
## What Does This Do

This sets the correct access level DSID to be mapped to the IIIF Manifest for items with the type of **Sound** and **Video**. Type is determined by the object model at https://github.com/utkdigitalinitiatives/iiif_assemble/blob/main/src/IIIF.php#L515-L537.

## So, did you test this?

If you have the [utk_digital](https://github.com/utkdigitalinitiatives/utk_digital) Vagrant running locally, resolve to a URL where the pattern of the collection PID is `/assemble/manifest/{namespace}/{id}`. Reference a PID with an model of either `islandora:sp-audioCModel` or `islandora:sp_videoCModel` objects having `PROXY_MP3` or `MP4` datastreams. The manifest should not reference an OBJ in the **items** property tree, If you want to, go a step further and test this in a viewer.