### PR TITLE
Fix logic when testing for empty values.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -113,7 +113,7 @@ class IIIF {
         $sets = array();
 
         foreach ($array as $label => $value) :
-            if ($value !== null or empty($value) !== true) :
+            if ($value !== null and empty($value) !== true) :
                 $sets[] = self::getLabelValuePair(
                     $label,
                     $value


### PR DESCRIPTION
[DIGITAL-1153](https://jirautk.atlassian.net/browse/DIGITAL-1153)

# What does this do?

This makes it so that a value must be not null and not empty to be split into descriptive metadata elements.  Previously, only one had to be true.

# How do I Test

If you have the utk_digital Vagrant running locally, replace the MODS of a current object with one from rfta.  Before pulling this branch in, you should see it has an empty value for the matching "Publication Identifier" label.  On replace with this branch, it will not.