### PR TITLE
Address DIGITAL-1133 and EXHIBIT-79.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -282,7 +282,7 @@ class IIIF {
     public function buildCanvas ($index, $uri, $pid) {
 
         $canvasId = $uri . '/canvas/' . $index;
-        $title = $this->xpath->query('titleInfo[not(@type="alternative")]');
+        $title = $this->xpath->query('titleInfo[not(@type="alternative")]')[0];
         $canvas = (object) [
                 "id" => $canvasId,
                 "type" => 'Canvas',

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -316,17 +316,15 @@ class IIIF {
     }
 
     public function buildCanvasWithPages ($index, $uri, $canvasData) {
-
         $canvasId = $uri . '/canvas/' . $index;
-
         $canvas = (object) [
             "id" => $canvasId,
-            "type" => 'Canvas'
+            "type" => 'Canvas',
+            "label" => self::getLanguageArray($canvasData[0]['title'], 'label', 'none')
         ];
 
-        foreach ($canvasData as $key => $pid) {
-
-            $iiifImage = self::getIIIFImageURI('JP2', $pid);
+        foreach ($canvasData as $key => $data) {
+            $iiifImage = self::getIIIFImageURI('JP2', $data['pid']);
 
             if (Request::responseStatus($iiifImage)) :
                 $responseImageBody = json_decode(Request::responseBody($iiifImage));
@@ -337,7 +335,7 @@ class IIIF {
                 $canvas->width = 360;
             endif;
 
-            $canvas->items[$key] = self::preparePage($canvasId, $pid, $key);
+            $canvas->items[$key] = self::preparePage($canvasId, $data['pid'], $key);
         }
 
         return $canvas;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -282,10 +282,11 @@ class IIIF {
     public function buildCanvas ($index, $uri, $pid) {
 
         $canvasId = $uri . '/canvas/' . $index;
-
+        $title = $this->xpath->query('titleInfo[not(@type="alternative")]');
         $canvas = (object) [
                 "id" => $canvasId,
-                "type" => 'Canvas'
+                "type" => 'Canvas',
+                "label" => self::getLanguageArray($title, 'label', 'none')
             ];
 
         if (in_array($this->type, ['Sound','Video'])) :

--- a/src/Request.php
+++ b/src/Request.php
@@ -72,8 +72,8 @@ class Request {
 
         $query = "PREFIX fedora-model: <info:fedora/fedora-system:def/model#> PREFIX fedora-rels-ext: ";
         $query .= "<info:fedora/fedora-system:def/relations-external#> PREFIX isl-rels-ext: ";
-        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$page \$numbers FROM <#ri> WHERE {{ \$page ";
-        $query .= "fedora-rels-ext:isMemberOf <info:fedora/" . $pid ."> ; isl-rels-ext:isPageNumber \$numbers .}}";
+        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$page \$numbers \$title FROM <#ri> WHERE {{ \$page ";
+        $query .= "fedora-rels-ext:isMemberOf <info:fedora/" . $pid ."> ; isl-rels-ext:isPageNumber \$numbers ; <http://purl.org/dc/elements/1.1/title> \$title . }}";
 
         $request .= self::escapeQuery($query);
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -73,7 +73,8 @@ class Request {
         $query = "PREFIX fedora-model: <info:fedora/fedora-system:def/model#> PREFIX fedora-rels-ext: ";
         $query .= "<info:fedora/fedora-system:def/relations-external#> PREFIX isl-rels-ext: ";
         $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$page \$numbers \$title FROM <#ri> WHERE {{ \$page ";
-        $query .= "fedora-rels-ext:isMemberOf <info:fedora/" . $pid ."> ; isl-rels-ext:isPageNumber \$numbers ; <http://purl.org/dc/elements/1.1/title> \$title . }}";
+        $query .= "fedora-rels-ext:isMemberOf <info:fedora/" . $pid ."> ; isl-rels-ext:isPageNumber \$numbers ;";
+        $query .= "fedora-model:label \$title . }}";
 
         $request .= self::escapeQuery($query);
 

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -57,11 +57,11 @@ class Utility {
         foreach ($result as $string) {
             $item = explode(',', $string);
             $pageNumber = $item[1];
-            $index[$pageNumber] = str_replace('info:fedora/', '', $item[0]);
+            $index[$pageNumber]['pid'] = str_replace('info:fedora/', '', $item[0]);
+            $index[$pageNumber]['title'] = $item[2];
         }
 
         ksort($index);
-
         $page = 0;
         $canvas = 0;
         $sequence = [];


### PR DESCRIPTION
[DIGITAL-1133](https://jirautk.atlassian.net/browse/DIGITAL-1133)
[EXHIBIT-79](https://jirautk.atlassian.net/browse/EXHIBIT-79)

# What does this do?

This adds a label to canvases in the manifest using the value of the page titles from Risearch.

# What has changed 

The standard query to Risearch for pages belonging to books now includes titles with the pids and the page numbers.  Code has been refactored to handle this modification so that it has no side effects.

# How can I test / What should I see?

This should add a label to each canvas with a language of `none` like so:

![image](https://user-images.githubusercontent.com/2692416/128261638-47e9ae7e-8765-49f5-a931-b4978c175ae2.png)

To test, use assemble in the utk_digital vagrant and point at a book-like object.  Use Islandora Sample Content Generator if you need one to test.

# Why should I care?

As seen in [EXHIBIT-79](https://jirautk.atlassian.net/browse/EXHIBIT-79), we currently have an error in Mirador gallery view.

# Is there anything else I should know?

~~Probably.  This work is approached from the standpoint of what's least resource intensive for Fedora.  We are using RISearch because of this, but the rdf:property we're using is based on the value of the DublinCore.  If the DublinCore is out of sync, we may have some odd labels.~~

The thing described above is no longer an issue.  As long as the Fedora label is updated, we should be good to go.
