### PR TITLE
Address DIGITAL-1154.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -355,8 +355,7 @@ class IIIF {
             $transcript_label = "Captions in English";
             $transcript_language = "en";
         endif;
-        return [
-            (object) [
+        return (object) [
                 "id" => $page . '/' . $this->pid . '/' . uniqid(),
                 "type" => 'Annotation',
                 "motivation" => "supplementing",
@@ -374,7 +373,6 @@ class IIIF {
                     ],
                 ],
                 "target" => $target
-            ]
         ];
     }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -360,7 +360,7 @@ class IIIF {
                 "id" => $page . '/' . $this->pid . '/' . uniqid(),
                 "type" => 'Annotation',
                 "motivation" => "supplementing",
-                "body" =>
+                "body" => [
                     (object) [
                         "id" => $datastream . $transcript_datastream,
                         "type" => "Text",
@@ -372,6 +372,7 @@ class IIIF {
                         ],
                         "language"=> $transcript_language
                     ],
+                ],
                 "target" => $target
             ]
         ];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -346,24 +346,15 @@ class IIIF {
 
     private function buildTranscript($language_code, $page, $target) {
         $datastream = $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/';
-        $data = [
-            (object) [
-                "en" => [
-                    (object)[
-                        "datastream" => "TRANSCRIPT",
-                        "label" => "Captions in English",
-                        "language" => "en"
-                    ]
-                ],
-                "es"  => [
-                    (object)[
-                        "datastream" => "TRANSCRIPT-ES",
-                        "label" => "Captions in Spanish",
-                        "language" => "es"
-                    ]
-                ],
-            ]
-        ];
+        if ($language_code == "es") :
+            $transcript_datastream = "TRANSCRIPT-ES";
+            $transcript_label = "Captions in Spanish";
+            $transcript_language = "es";
+        else :
+            $transcript_datastream = "TRANSCRIPT";
+            $transcript_label = "Captions in English";
+            $transcript_language = "en";
+        endif;
         return [
             (object) [
                 "id" => $page . '/' . $this->pid . '/' . uniqid(),
@@ -371,15 +362,15 @@ class IIIF {
                 "motivation" => "supplementing",
                 "body" =>
                     (object) [
-                        "id" => $datastream . $data[$language_code]['datastream'],
+                        "id" => $datastream . $transcript_datastream,
                         "type" => "Text",
                         "format" => "text/vtt",
                         "label" => [
                             (object) [
-                                "en"=> $data[$language_code]["label"]
+                                "en"=> $transcript_label
                             ]
                         ],
-                        "language"=> $data[$language_code]["language"]
+                        "language"=> $transcript_language
                     ],
                 "target" => $target
             ]

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -364,14 +364,15 @@ class IIIF {
                         "id" => $datastream . $transcript_datastream,
                         "type" => "Text",
                         "format" => "text/vtt",
-                        "label" => [
+                        "label" =>
                             (object) [
-                                "en"=> $transcript_label
-                            ]
-                        ],
+                                "en"=> [
+                                    $transcript_label
+                                ]
+                            ],
                         "language"=> $transcript_language
+                        ],
                     ],
-                ],
                 "target" => $target
         ];
     }

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -379,7 +379,6 @@ class IIIF {
 
     private function getTranscipts($pagenumber, $target) {
         $datastreams = $this::getDatastreamIds();
-        $datastream = $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/';
         $transcripts = [];
         if (in_array('TRANSCRIPT', $datastreams)) :
             array_push($transcripts, $this::buildTranscript('en', $pagenumber, $target));

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -344,55 +344,57 @@ class IIIF {
 
     }
 
+    private function buildTranscript($language_code, $page, $target) {
+        $datastream = $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/';
+        $data = [
+            (object) [
+                "en" => [
+                    (object)[
+                        "datastream" => "TRANSCRIPT",
+                        "label" => "Captions in English",
+                        "language" => "en"
+                    ]
+                ],
+                "es"  => [
+                    (object)[
+                        "datastream" => "TRANSCRIPT-ES",
+                        "label" => "Captions in Spanish",
+                        "language" => "es"
+                    ]
+                ],
+            ]
+        ];
+        return [
+            (object) [
+                "id" => $page . '/' . $this->pid . '/' . uniqid(),
+                "type" => 'Annotation',
+                "motivation" => "supplementing",
+                "body" =>
+                    (object) [
+                        "id" => $datastream . $data[$language_code]['datastream'],
+                        "type" => "Text",
+                        "format" => "text/vtt",
+                        "label" => [
+                            (object) [
+                                "en"=> $data[$language_code]["label"]
+                            ]
+                        ],
+                        "language"=> $data[$language_code]["language"]
+                    ],
+                "target" => $target
+            ]
+        ];
+    }
+
     private function getTranscipts($pagenumber, $target) {
         $datastreams = $this::getDatastreamIds();
         $datastream = $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/';
         $transcripts = [];
         if (in_array('TRANSCRIPT', $datastreams)) :
-            $english_transcript = [
-                (object) [
-                    "id" => $pagenumber . '/' . $this->pid . '/' . uniqid(),
-                    "type" => 'Annotation',
-                    "motivation" => "supplementing",
-                    "body" =>
-                        (object) [
-                            "id" => $datastream . 'TRANSCRIPT',
-                            "type" => "Text",
-						    "format" => "text/vtt",
-                            "label" => [
-                                (object) [
-                                    "en"=> "Captions in English"
-                                ]
-                            ],
-                            "language"=> "en"
-                        ],
-                    "target" => $target
-                ]
-            ];
-            array_push($transcripts, $english_transcript);
+            array_push($transcripts, $this::buildTranscript('en', $pagenumber, $target));
         endif;
         if (in_array('TRANSCRIPT-ES', $datastreams)) :
-            $spanish_transcript = [
-                (object) [
-                    "id" => $pagenumber . '/' . $this->pid . '/' . uniqid(),
-                    "type" => 'Annotation',
-                    "motivation" => "supplementing",
-                    "body" =>
-                        (object) [
-                            "id" => $datastream . 'TRANSCRIPT-ES',
-                            "type" => "Text",
-                            "format" => "text/vtt",
-                            "label" => [
-                                (object) [
-                                    "none"=> "Captions in Spanish"
-                                ]
-                            ],
-                            "language"=> "es"
-                        ],
-                    "target" => $target
-                ]
-            ];
-            array_push($transcripts, $spanish_transcript);
+            array_push($transcripts, $this::buildTranscript('es', $pagenumber, $target));
         endif;
         return $transcripts;
     }

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -348,7 +348,7 @@ class IIIF {
         $datastream = $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/';
         if ($language_code == "es") :
             $transcript_datastream = "TRANSCRIPT-ES";
-            $transcript_label = "Captions in Spanish";
+            $transcript_label = "Subtítulos en español";
             $transcript_language = "es";
         else :
             $transcript_datastream = "TRANSCRIPT";
@@ -366,7 +366,7 @@ class IIIF {
                         "format" => "text/vtt",
                         "label" =>
                             (object) [
-                                "en"=> [
+                                $transcript_language => [
                                     $transcript_label
                                 ]
                             ],

--- a/src/Request.php
+++ b/src/Request.php
@@ -96,6 +96,16 @@ class Request {
 
     }
 
+    public static function getDatastreams($pid, $format = 'csv'){
+        $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';
+        $query = "PREFIX fedora: <info:fedora/fedora-system:def/view#> SELECT \$o FROM <#ri> WHERE {{ ";
+        $query .= "<info:fedora/" . $pid ."> fedora:disseminates \$o . }}";
+
+        $request .= self::escapeQuery($query);
+
+        return self::curlRequest($request);
+    }
+
     public static function getDatastream ($dsid, $pid, $format = 'XML') {
 
         $request = $_ENV['FEDORA_URL'] . '/objects/' . $pid;


### PR DESCRIPTION
# What Does This Do

This adds transcripts to Islandora Audio and Video objects if they exist. If an object has a TRANSCRIPT or TRANSCRIPT-ES datastream and its type is identified as "Sound" or "Video", the appropriate transcript(s) is added.

# How Does This Work

This uses the Fedora resource index to determine the datastreams associated with a particular object.  Then, when items are getting added to the AnnotationPage, we add additional items with the motivation of supplementing to the function that paints the primary canvas.

# Could This Be Better

Yep

# Are you willing to make this better

Yep

# Anything Else You Should Know

I haven't tested this in Mirador to see what happens. For some reason, I get an error trying to spin up my local copy.



