### PR TITLE
Make range generating conditional specific to RFTA partType values.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -449,18 +449,19 @@ class IIIF {
 
         foreach ($parts as $index => $part) :
 
-            if (in_array($part->getAttribute('partType'), ['Interview Questions', 'Chapters'])) :
+            $partType = $part->getAttribute('partType');
+
+            if (in_array($partType, ['Interview Questions', 'Chapters'])) :
 
                 $label = $part->getElementsByTagNameNS('http://www.pbcore.org/PBCore/PBCoreNamespace.html', 'pbcoreTitle');
                 $startTime = $part->getAttribute('startTime');
                 $endTime = $part->getAttribute('endTime');
 
-                $partTypeAnnotation = $part->getAttribute('partTypeAnnotation');
-                $range = Utility::sanitizeLabel($partTypeAnnotation);
+                $range = Utility::sanitizeLabel($partType);
 
                 $ranges[$range]['type'] = 'Range';
                 $ranges[$range]['id'] = $uri . '/' . $range;
-                $ranges[$range]['label'] = self::getLanguageArray($partTypeAnnotation, 'label');
+                $ranges[$range]['label'] = self::getLanguageArray($partType, 'label');
                 $ranges[$range]['items'][] = (object) [
                     'type' => 'Range',
                     'id' => $uri . '/' . $range . '/' . $index,

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -449,7 +449,7 @@ class IIIF {
 
         foreach ($parts as $index => $part) :
 
-            if ($part->getAttribute('partType') === 'iiif') :
+            if (in_array($part->getAttribute('partType'), ['Interview Questions', 'Chapters'])) :
 
                 $label = $part->getElementsByTagNameNS('http://www.pbcore.org/PBCore/PBCoreNamespace.html', 'pbcoreTitle');
                 $startTime = $part->getAttribute('startTime');


### PR DESCRIPTION
[DIGITAL-1168](https://jirautk.atlassian.net/browse/DIGITAL-1168)

# What does this do?

Initially, a decision was made to set the partType attribute in the pbcore as `iiif`. This was altered in the past few months to be specific to the RFTA values of **Chapters**, **Interview Questions**, and **geographic**. This pull request addresses that change and only allows pbcore parts with the partType of **Chapters** and **Interview Questions** to render to structures.

# How do I Test

Grab a MODS record that has pbcore with partTypes of **Chapters**, **Interview Questions**, and **geographic**. Structures will output in the manifest with multiple rangers for just the allowed types iof **Chapters** and **Interview Questions**.

# Additional Notes
Note: This does not address any issue related to the the temporal dimension media fragment.