### PR TITLE
Add type of resource to metadata.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -97,6 +97,7 @@ class IIIF {
             'Date' => $this->xpath->query('originInfo/dateCreated|originInfo/dateOther'),
             'Publication Date' => $this->xpath->query('originInfo/dateIssued'),
             'Form' => $this->xpath->query('physicalDescription/form[not(@type="material")]'),
+            'Type of Resource' => $this->type,
             'Extent' => $this->xpath->query('physicalDescription/extent'),
             'Topic' => $this->xpath->query('subject/topic'),
             'Coverage' => $this->xpath->query('subject/geographic'),

--- a/src/Request.php
+++ b/src/Request.php
@@ -110,6 +110,17 @@ class Request {
 
     }
 
+
+    public static function getDatastreams($pid, $format = 'csv'){
+        $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';
+        $query = "PREFIX fedora: <info:fedora/fedora-system:def/view#> SELECT \$o FROM <#ri> WHERE {{ ";
+        $query .= "<info:fedora/" . $pid ."> fedora:disseminates \$o . }}";
+
+        $request .= self::escapeQuery($query);
+
+        return self::curlRequest($request);
+    }
+
     public static function getDatastream ($dsid, $pid, $format = 'XML') {
 
         $request = $_ENV['FEDORA_URL'] . '/objects/' . $pid;


### PR DESCRIPTION
# What does this do?

Adds a "Type of Resource" metadata value to the manifest based on the type of the resource.

Readds a method that we accidentally deleted earlier this week.

# How to test

Look at metadata values.  Is there a typeOfResource?
Are things generating correctly.