### PR TITLE
Address DIGITAL-1259.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -524,16 +524,14 @@ class IIIF {
                 $label = $part->getElementsByTagNameNS('http://www.pbcore.org/PBCore/PBCoreNamespace.html', 'pbcoreTitle');
                 $startTime = $part->getAttribute('startTime');
                 $endTime = $part->getAttribute('endTime');
-                $part_type_label = self::getLanguageArray($partType, 'label');
-                if ($part_type_label == 'geographic') :
-                    $part_type_label = 'Places Mentioned';
+                if ($partType == 'geographic'):
+                    $partType = 'Places Mentioned';
                 endif;
-
                 $range = Utility::sanitizeLabel($partType);
 
                 $ranges[$range]['type'] = 'Range';
                 $ranges[$range]['id'] = $uri . '/' . $range;
-                $ranges[$range]['label'] = $part_type_label;
+                $ranges[$range]['label'] = self::getLanguageArray($partType, 'label');
                 $ranges[$range]['items'][] = (object) [
                     'type' => 'Range',
                     'id' => $uri . '/' . $range . '/' . $index,


### PR DESCRIPTION
## What Does This Do

Adds a new range (Places Mentioned) for RFTA.

## How does it Work

This is pretty simple:

1. We build a range if there is a corresponding "pbcore:partType" that is equal to `geographic`.
2. Then, we switch the value to `Places Mentioned`

## How do I review

To keep things simple, I've already made this live on the server here:

https://digital.lib.utk.edu/assemble/manifest/rfta/165

Does it look valid? Are things spelled correctly?

## Going One Step Forward

1. Pull down or clone iiif canopy and build and start it with yarn.
2. Navigate to Rodriguez and take a look at things in the browser.

![image](https://user-images.githubusercontent.com/2692416/136830852-e06bc1fa-b337-428e-a31f-34d97aa89475.png)
