### PR TITLE
Address DIGITAL-1303.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -149,7 +149,7 @@ class IIIF {
 
         $providing_institution = $this->xpath->query('recordInfo/recordContentSource');
         return (object) [
-            'label' => self::getLanguageArray('Attribution', 'label'),
+            'label' => self::getLanguageArray('Provided by', 'label'),
             'value' => self::getLanguageArray($providing_institution, 'value')
         ];
 


### PR DESCRIPTION
## What Does This Do

Uses the value of `recordInfo/recordContentSource` as our requiredStatement.

## What's New

Currently, we are writing a static value for requiredStatement pointing at the University of Tennessee.  This isn't correct.  This attempts to minimally drive this value with the value of `recordInfo/recordContentSource`.

## How Can I Test?

1. Pull the branch into utk_digital.
2. Look at corresponding manifests for MODS records with different values for recordInfo/recordContentSource.
3. What does a generated manifest look like?
