### PR TITLE
Update label.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -99,7 +99,7 @@ class IIIF {
             'Format' => $this->xpath->query('physicalDescription/form[not(@type="material")]'),
             'Extent' => $this->xpath->query('physicalDescription/extent'),
             'Subject' => $this->xpath->query('subject[not(@displayLabel="Narrator Class")]/topic'),
-            'Narrator Class' => $this->xpath->query('subject[@displayLabel="Narrator Class"]/topic'),
+            'Narrator Role' => $this->xpath->query('subject[@displayLabel="Narrator Class"]/topic'),
             'Place' => $this->xpath->query('subject/geographic'),
             'Time Period' => $this->xpath->query('subject/temporal'),
             'Publication Identifier' => $this->xpath->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn'])


### PR DESCRIPTION
## What's New

This very simply changes the label we use for values found at `subject[@displayLabel="Narrator Class"]`. The actual value within the MODS will remain the same, but hopefully the substitution of "Role" over "Class" is a bit more accessible to users.

## How Can I Test?

1. Pull the branch into utk_digital.
2. Look at corresponding manifests for MODS records with this subject type and ensure that it appears.