### PR TITLE
Add Abstract and other things to manifest.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -69,7 +69,7 @@ class IIIF {
         $manifest['id'] = $id;
         $manifest['type'] = 'Manifest';
         $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
-        $manifest['summary'] = self::getLanguageArray($this->xpath->query('abstract'), 'value');
+        $manifest['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
         $manifest['metadata'] = self::buildMetadata();
         $manifest['rights'] = self::buildRights();
         $manifest['requiredStatement'] = self::buildRequiredStatement();
@@ -102,6 +102,8 @@ class IIIF {
             'Narrator Class' => $this->xpath->query('subject[@displayLabel="Narrator Class"]/topic'),
             'Place' => $this->xpath->query('subject/geographic'),
             'Time Period' => $this->xpath->query('subject/temporal'),
+            'Description' => $this->xpath->query('abstract[not(@lang)]'),
+            'Descripción' => $this->xpath->query('abstract[@lang="spa"]'),
             'Publication Identifier' => $this->xpath->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn'])
         );
         $metadata_with_names = $this->add_names_to_metadata($metadata);

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -68,7 +68,7 @@ class IIIF {
         $manifest['@context'] = ['https://iiif.io/api/presentation/3/context.json'];
         $manifest['id'] = $id;
         $manifest['type'] = 'Manifest';
-        $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")][not(@lang="spa")]'), 'value');
+        $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")][not(@lang)]'), 'value');
         $manifest['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
         $manifest['metadata'] = self::buildMetadata();
         $manifest['rights'] = self::buildRights();

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -68,7 +68,7 @@ class IIIF {
         $manifest['@context'] = ['https://iiif.io/api/presentation/3/context.json'];
         $manifest['id'] = $id;
         $manifest['type'] = 'Manifest';
-        $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
+        $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")][not(@lang="spa")]'), 'value');
         $manifest['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
         $manifest['metadata'] = self::buildMetadata();
         $manifest['rights'] = self::buildRights();

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -104,6 +104,7 @@ class IIIF {
             'Time Period' => $this->xpath->query('subject/temporal'),
             'Description' => $this->xpath->query('abstract[not(@lang)]'),
             'Descripción' => $this->xpath->query('abstract[@lang="spa"]'),
+            'Título' => $this->xpath->query('titleInfo[@lang="spa"]/title'),
             'Publication Identifier' => $this->xpath->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn'])
         );
         $metadata_with_names = $this->add_names_to_metadata($metadata);
@@ -122,12 +123,19 @@ class IIIF {
     public function validateMetadata ($array) {
 
         $sets = array();
+        $spanish_labels = array('Descripción', 'Título');
 
         foreach ($array as $label => $value) :
             if ($value !== null and empty($value) !== true) :
+                if (in_array($label, $spanish_labels)) :
+                    $lang = 'es';
+                else :
+                    $lang = 'en';
+                endif;
                 $sets[] = self::getLabelValuePair(
                     $label,
-                    $value
+                    $value,
+                    $lang
                 );
             endif;
         endforeach;
@@ -564,12 +572,12 @@ class IIIF {
 
     }
 
-    public function getLabelValuePair ($label, $value) {
+    public function getLabelValuePair ($label, $value, $language="en") {
 
         if ($value !== null) {
             return (object) [
-                'label' => self::getLanguageArray($label, 'label'),
-                'value' => self::getLanguageArray($value, 'value')
+                'label' => self::getLanguageArray($label, 'label', $language),
+                'value' => self::getLanguageArray($value, 'value', $language)
             ];
         } else {
             return null;


### PR DESCRIPTION
## What Does This Do

1. Adds abstract to metadata.
2. Adds a Spanish abstract and Spanish title to metadata.
3. Refactors things to allow for metadata elements to be in other languages. (not a great approach, but okay for now).
4. Only allows for labels in English (for now).

## How can you test?

Check this branch out in utk_digital and do an update on an object with a Spanish RFTA MODS record.  Look at the updated manifest in assemble.