### PR TITLE
Address Digital-1182.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -647,13 +647,12 @@ class IIIF {
     }
 
     private function getBibframeDuration($dsid) {
-//        $durations = Request::getBibframeDuration($this->pid, $dsid, 'csv');
-//        $duration = explode("\n", $durations['body'])[1];
-//        $split_duration = explode(":", $duration);
-//        $hours = intval($split_duration[0]) *  60 * 60;
-//        $minutes = intval($split_duration[1]) * 60;
-//        return $hours + $minutes + intval($split_duration[2]);
-        return 300;
+        $durations = Request::getBibframeDuration($this->pid, $dsid, 'csv');
+        $duration = explode("\n", $durations['body'])[1];
+        $split_duration = explode(":", $duration);
+        $hours = intval($split_duration[0]) *  60 * 60;
+        $minutes = intval($split_duration[1]) * 60;
+        return $hours + $minutes + intval($split_duration[2]);
     }
 
     private static function determineTypeByModel ($islandoraModel) {


### PR DESCRIPTION
## What Does This Do?

Adds an `accompanyingCanvas` for Sound manifests.

## Why?

In Canopy, our viewer needs to display an image agnostic ally for sound things.  Following presentation v3, this should be done with the `accompanyingCanvas` property.  You can read more about it here and its rules:

https://iiif.io/api/presentation/3.0/#accompanyingcanvas

The work here is largely a take on this recipe published by the IIIF community:

https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/

From the recipe is a very close example of what we're trying to do here:

> You might want to have an image available while an audio-only Canvas is playing or, conversely, audio available while a user is navigating an image-only Manifest.

## But what about canopy?

That will be handled in a later pull request to that repo to leverage work here.

## How Can I Review

Well ....

It's complicated. To actually have this work right you have to add an audio object to your Islandora instance, add duration to it via RELS-INT in some way (API-M), and then update the manifest on this branch.

If all of that seems too much, here is a screenshot of this part of the manifest based on the attached code:

![image](https://user-images.githubusercontent.com/2692416/139928558-db16a9e8-0c92-4383-8f84-141efc72110e.png)

Review this versus the spec and related recipe and let me know if there are questions.