### PR TITLE
Address DIGITAL-1329: add language to manifest.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -106,11 +106,20 @@ class IIIF {
             'Descripción' => $this->xpath->query('abstract[@lang="spa"]'),
             'Título' => $this->xpath->query('titleInfo[@lang="spa"]/title'),
             'Publication Identifier' => $this->xpath->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn']),
-            'Browse' => $this->browse_sanitize($this->xpath->query('note[@displayLabel="Browse"]'))
+            'Browse' => $this->browse_sanitize($this->xpath->query('note[@displayLabel="Browse"]')),
+            'Language' => $this->determine_language($this->xpath->query('language/languageTerm'))
         );
         $metadata_with_names = $this->add_names_to_metadata($metadata);
         return self::validateMetadata($metadata_with_names);
 
+    }
+
+    private function determine_language($value) {
+        $language = array('English');
+        if (count($value) > 0){
+            $language = $value;
+        }
+        return $language;
     }
 
     private function browse_sanitize($value) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -107,19 +107,11 @@ class IIIF {
             'Título' => $this->xpath->query('titleInfo[@lang="spa"]/title'),
             'Publication Identifier' => $this->xpath->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn']),
             'Browse' => $this->browse_sanitize($this->xpath->query('note[@displayLabel="Browse"]')),
-            'Language' => $this->determine_language($this->xpath->query('language/languageTerm'))
+            'Language' => $this->xpath->query('language/languageTerm')
         );
         $metadata_with_names = $this->add_names_to_metadata($metadata);
         return self::validateMetadata($metadata_with_names);
 
-    }
-
-    private function determine_language($value) {
-        $language = array('English');
-        if (count($value) > 0){
-            $language = $value;
-        }
-        return $language;
     }
 
     private function browse_sanitize($value) {


### PR DESCRIPTION
## What Does This Do

Adds language  to metadata property in each manifest.

## How does it work

If there is a defined language, we copy those over.  If there isn't, we write English

## Why

The RFTA team has asked to build a facet to limit languages on, but currently we have nothing in the manifest to base this on.  This adds that.

## How can you test

Spin up utk_digital, add an object, add a MODS record from UTK (with or without a language), do a `get` request on the object with cache update command. Something like:

`http://localhost:8000/assemble/manifest/test/2?update=1`

Look for language in the `metadata` property.