### PR TITLE
Address DIGITAL-1341: Add interview questions for Spanish oral histor…

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -567,7 +567,7 @@ class IIIF {
 
             $partType = $part->getAttribute('partType');
 
-            if (in_array($partType, ['Interview Questions', 'Chapters', 'geographic'])) :
+            if (in_array($partType, ['Interview Questions', 'Chapters', 'geographic', 'Preguntas de entrevista'])) :
 
                 $label = $part->getElementsByTagNameNS('http://www.pbcore.org/PBCore/PBCoreNamespace.html', 'pbcoreTitle');
                 $startTime = $part->getAttribute('startTime');


### PR DESCRIPTION
## What Does this Do

Adds `Preguntas de entrevista` as an option for building ranges and structures. 

## Why

In order to get these to screen in canopy, this needs to be added.
