### PR TITLE
Address DIGITAL-1380.

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -68,7 +68,7 @@ class Collection
                 return json_encode($object);
             endif;
         else :
-            return json_encode($items);
+            return $object['status'];
         endif;
 
     }

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -49,10 +49,10 @@ class IIIF {
 
         foreach ($this->object as $item) {
             $items[] = (object) [
-                'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item),
+                'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item->pid),
                 'type' => 'Manifest',
                 'label' => (object) [
-                    'none' => [$item]
+                    'none' => [$item->label]
                     ]
             ];
         }

--- a/src/Request.php
+++ b/src/Request.php
@@ -104,8 +104,8 @@ class Request {
 
         $query = "PREFIX fedora-model: <info:fedora/fedora-system:def/model#> PREFIX fedora-rels-ext: ";
         $query .= "<info:fedora/fedora-system:def/relations-external#> PREFIX isl-rels-ext: ";
-        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$item FROM <#ri> WHERE {{ \$item ";
-        $query .= "fedora-rels-ext:isMemberOfCollection <info:fedora/" . $pid ."> .}}";
+        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$item \$label FROM <#ri> WHERE {{ \$item ";
+        $query .= "fedora-rels-ext:isMemberOfCollection <info:fedora/" . $pid ."> ; <info:fedora/fedora-system:def/model#label> \$label . }}";
 
         $request .= self::escapeQuery($query);
 

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -86,7 +86,10 @@ class Utility {
 
         foreach ($result as $string) {
             $item = explode(',', $string);
-            $index[] = str_replace('info:fedora/', '', $item[0]);
+            $index[] = (object) [
+                'pid' => str_replace('info:fedora/', '', $item[0]),
+                'label' => $item[1],
+            ];
         }
 
         return $index;

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -86,9 +86,15 @@ class Utility {
 
         foreach ($result as $string) {
             $item = explode(',', $string);
+            if(str_starts_with($item[1], '"')) {
+                $split = explode('"', $string);
+                $label = str_replace('"', '', $split[1]);
+            } else {
+                $label = $item[1];
+            }
             $index[] = (object) [
                 'pid' => str_replace('info:fedora/', '', $item[0]),
-                'label' => $item[1],
+                'label' => $label,
             ];
         }
 


### PR DESCRIPTION
# What Does This Do

This uses the label for an object from RISearch as the label of an object in a collection manifest instead of the PID.  It also changes the return for a failed collection request.

# How Do I Test

You can test locally or do it live:

While on the current branch `main`, look at the collection manifest for your favorite collection.  Something like:

https://digital.lib.utk.edu/assemble/collection/collections/rfta?update=1

Checkout the label associated with a manifest that belongs to the collection:

![image](https://user-images.githubusercontent.com/2692416/159979707-5a0af8ab-a931-44d1-879b-ca0f36b1fa73.png)

Notice that the label is the PID. 🤮 

Now, checkout the current branch and look at the same thing:

https://digital.lib.utk.edu/assemble/collection/collections/rfta?update=1

![image](https://user-images.githubusercontent.com/2692416/159986716-e0e240cb-b9d3-460b-b3d9-ff6d9f5ff510.png)

# Is this really necessary?

No, but it's definitely a quality of life improvement.  Also, more in line with spec in my opinion.





