### PR TITLE
Address DIGITAL-1378.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -502,7 +502,7 @@ class IIIF {
                 "id" => $page . '/' . $pid . '/' . uniqid(),
                 "type" => 'Annotation',
                 "motivation" => "painting",
-                "body" => [self::paintCanvas($pid)],
+                "body" => self::paintCanvas($pid),
                 "target" => $target
             ]
         ];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -527,13 +527,13 @@ class IIIF {
             $body['width'] = $response->width;
             $body['height'] = $response->height;;
             $body['format'] = "image/jpeg";
-            $body['service'] = [
+            $body['service'] =
                 (object) [
                     '@id' => $response->{'@id'},
                     '@type' => $response->{'@context'},
                     'profile' => $response->profile[0],
                     ]
-            ];
+            ;
         else :
             $body['id'] = $fallback;
             $body['type'] = "Image";

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -445,7 +445,7 @@ class IIIF {
                 "id" => $page . '/' . $this->pid . '/' . uniqid(),
                 "type" => 'Annotation',
                 "motivation" => "supplementing",
-                "body" => [
+                "body" =>
                     (object) [
                         "id" => $datastream . $transcript_datastream,
                         "type" => "Text",
@@ -458,7 +458,6 @@ class IIIF {
                             ],
                         "language"=> $transcript_language
                         ],
-                    ],
                 "target" => $target
         ];
     }

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -527,13 +527,13 @@ class IIIF {
             $body['width'] = $response->width;
             $body['height'] = $response->height;;
             $body['format'] = "image/jpeg";
-            $body['service'] =
+            $body['service'] = [
                 (object) [
                     '@id' => $response->{'@id'},
                     '@type' => $response->{'@context'},
                     'profile' => $response->profile[0],
-                    ]
-            ;
+                ]
+            ];
         else :
             $body['id'] = $fallback;
             $body['type'] = "Image";

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -528,10 +528,12 @@ class IIIF {
             $body['width'] = $response->width;
             $body['height'] = $response->height;;
             $body['format'] = "image/jpeg";
-            $body['service'] = (object) [
-                '@id' => $response->{'@id'},
-                '@type' => $response->{'@context'},
-                'profile' => $response->profile[0],
+            $body['service'] = [
+                (object) [
+                    '@id' => $response->{'@id'},
+                    '@type' => $response->{'@context'},
+                    'profile' => $response->profile[0],
+                    ]
             ];
         else :
             $body['id'] = $fallback;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -482,7 +482,7 @@ class IIIF {
                 "id" => $page . '/' . $this->pid . '/' . uniqid(),
                 "type" => 'Annotation',
                 "motivation" => "painting",
-                "body" => [self::paintAccompanyingImage('TN')],
+                "body" => self::paintAccompanyingImage('TN'),
                 "target" => $target
             ]
         ];


### PR DESCRIPTION
# What Does This Do?

1. Makes `body` a JSON-like object rather than an array.
2. Makes `service` an array of JSON-like objects.
3. Addresses [Issue 22](https://github.com/utkdigitalinitiatives/iiif_assemble/issues/22).
4. Moves captions to `annotations` property of `Canvas` following [Recipe 219: Using Caption and Subtitle Files with Video Content](https://iiif.io/api/cookbook/recipe/0219-using-caption-file/).

# Why Are We Doing This?

Our manifests are currently way out of spec.  These problems make it impossible to use community based tools like [Clover IIIF](https://github.com/samvera-labs/clover-iiif). This gets things in order so that these tools can be used.

This attempts to follow [Recipe 219: Using Caption and Subtitle Files with Video Content](https://iiif.io/api/cookbook/recipe/0219-using-caption-file/).  It's important because the presentation v3 spec says:

> Annotations that do not have the motivation value painting must not be in pages [referenced](https://iiif.io/api/presentation/3.0/#12-terminology) in items, but instead in the annotations property. Referenced, external Annotation Pages must have the id and type properties.

# Will this break things elsewhere.

Absolutely, this changes the pattern for where to find properties in the body of Annotations and the service property of body because it changes their type.

It's important then that we address technical debt related to these prior to merge specifically in Canopy and Exhibits.

# What Should this look like in Clover?

Here is a video from CDF with a transcript in Clover (note: there is a bug in Clover right now that makes loading transcripts with many cues slow):

![image](https://user-images.githubusercontent.com/2692416/164015702-0b63d2bc-0c80-4a45-95bb-9902e14a24e8.png)

# What must happen prior to merge and deploy?

- [x] Address changes needed in Canopy to find transcripts in this property.
- [x] Address changes needed in Exhibits for Galston or come up with a way to make that unaffected.
