### PR TITLE
Add thumbnails according to Image 2.1.1 spec to manifests.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -44,7 +44,7 @@ class IIIF {
         }
         $collection['viewingDirection'] = 'left-to-right';
         $collection['behavior'] = ['unordered'];
-        $collection['partOf'] = self::getPartOf($this->pid);
+        $collection['partOf'] = self::getPartOf();
         $collection['thumbnail'] = self::buildCollectionThumbnails();
         $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
         $collection['items'] = self::buildCollectionItems();
@@ -493,7 +493,7 @@ class IIIF {
         ];
     }
 
-    private function getPartOf($pid) {
+    private function getPartOf() {
         $all_collections = [];
         $collections = Request::getCollectionPidIsPartOf($this->pid, 'csv');
         $split_collections = explode("\n", $collections['body']);

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -64,12 +64,24 @@ class IIIF {
                 'label' => (object) [
                     'none' => [$item->label]
                     ],
-                'thumbnail' => self::buildThumbnail(200, 200)
+                'thumbnail' => [self::useFedoraThumbnail($item->pid)]
             ];
         }
 
         return $items;
 
+    }
+
+    private function useFedoraThumbnail ($pid) {
+
+        $item = array();
+        $item['id'] = $this->url . '/collections/islandora/object/' . $pid . '/datastream/TN/view';
+        $item['height'] = 200;
+        $item['width'] = 200;
+        $item['type'] = 'Image';
+        $item['format'] = 'image/jpeg';
+
+        return $item;
     }
 
     private function buildCollectionThumbnails ($items = []) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -44,6 +44,7 @@ class IIIF {
         }
         $collection['viewingDirection'] = 'left-to-right';
         $collection['behavior'] = ['unordered'];
+        $collection['partOf'] = self::getPartOf($this->pid);
         $collection['thumbnail'] = self::buildCollectionThumbnails();
         $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
         $collection['items'] = self::buildCollectionItems();
@@ -490,6 +491,22 @@ class IIIF {
                     ],
                 "target" => $target
         ];
+    }
+
+    private function getPartOf($pid) {
+        $all_collections = [];
+        $collections = Request::getCollectionPidIsPartOf($this->pid, 'csv');
+        $split_collections = explode("\n", $collections['body']);
+        $split_collections = array_diff( $split_collections, ['"collection"', ''] );
+        foreach ($split_collections as $collection) :
+            $new_collection = ( object ) [
+                "id" => $this->url . '/collections/islandora/object/' . str_replace('info:fedora/', '', $collection),
+                "type" => "Collection"
+            ];
+            array_push($all_collections, $new_collection);
+        endforeach;
+        return $all_collections;
+
     }
 
     private function getTranscipts($pagenumber, $target) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -106,6 +106,7 @@ class IIIF {
         $manifest['thumbnail'] = self::buildThumbnail(200, 200);
         $manifest['items'] = self::buildItems($id);
         $manifest['seeAlso'] = self::buildSeeAlso();
+        $manifest['partOf'] = self::getPartOf();
 
         if ($this->type === 'Book') {
             $manifest['behavior'] = ["paged"];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -38,9 +38,13 @@ class IIIF {
         $collection['@context'] = ['https://iiif.io/api/presentation/3/context.json'];
         $collection['id'] = $id;
         $collection['type'] = 'Collection';
+        $collection['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
+        $collection['viewingDirection'] = 'left-to-right';
+        $collection['behavior'] = ['unordered'];
         $collection['thumbnail'] = self::buildCollectionThumbnails();
         $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
         $collection['items'] = self::buildCollectionItems();
+        $collection['provider'] = self::buildProvider();
 
         return json_encode($collection);
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -50,9 +50,21 @@ class IIIF {
         $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
         $collection['items'] = self::buildCollectionItems();
         $collection['provider'] = self::buildProvider();
+        $collection['homepage'] = [ self::buildHomepage($this->pid, $collection['label']) ];
 
         return json_encode($collection);
 
+    }
+
+
+    private function buildHomepage ($pid, $label) {
+        $homepage = (object) [
+            'id' => $this->url . '/collections/islandora/object/' . $pid,
+            'label' => $label,
+            'type' => 'Text',
+            'format' => 'text/html'
+        ];
+        return $homepage;
     }
 
     private function buildCollectionItems ($items = []) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -38,7 +38,10 @@ class IIIF {
         $collection['@context'] = ['https://iiif.io/api/presentation/3/context.json'];
         $collection['id'] = $id;
         $collection['type'] = 'Collection';
-        $collection['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
+        $summary = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
+        if ($summary->en[0] != "") {
+            $collection['summary'] = $summary;
+        }
         $collection['viewingDirection'] = 'left-to-right';
         $collection['behavior'] = ['unordered'];
         $collection['thumbnail'] = self::buildCollectionThumbnails();

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -133,6 +133,7 @@ class IIIF {
         $manifest['items'] = self::buildItems($id);
         $manifest['seeAlso'] = self::buildSeeAlso();
         $manifest['partOf'] = self::getPartOf();
+        $manifest['homepage'] = [ self::buildHomepage($this->pid, $manifest['label']) ];
 
         if ($this->type === 'Book') {
             $manifest['behavior'] = ["paged"];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -45,6 +45,7 @@ class IIIF {
         $collection['viewingDirection'] = 'left-to-right';
         $collection['behavior'] = ['unordered'];
         $collection['partOf'] = self::getPartOf();
+        $collection['metadata'] = self::buildMetadata();
         $collection['thumbnail'] = self::buildCollectionThumbnails();
         $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
         $collection['items'] = self::buildCollectionItems();

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -63,7 +63,8 @@ class IIIF {
                 'type' => 'Manifest',
                 'label' => (object) [
                     'none' => [$item->label]
-                    ]
+                    ],
+                'thumbnail' => self::buildThumbnail(200, 200)
             ];
         }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -39,7 +39,7 @@ class IIIF {
         $collection['id'] = $id;
         $collection['type'] = 'Collection';
         $summary = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
-        if ($summary->en[0] != "") {
+        if (is_array($summary->en) && $summary->en[0] != "") {
             $collection['summary'] = $summary;
         }
         $collection['viewingDirection'] = 'left-to-right';

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -74,7 +74,6 @@ class IIIF {
 
         foreach ($this->object as $item) {
             $items[] = (object) [
-                /*'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item->pid),*/
                 'id' => $this->url . '/iiif/2/collections~islandora~object~' . $item->pid . '~datastream~TN/full/full/0/default.jpg',
                 'type' => 'Image',
                 'format' => 'image/jpeg',

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -38,6 +38,7 @@ class IIIF {
         $collection['@context'] = ['https://iiif.io/api/presentation/3/context.json'];
         $collection['id'] = $id;
         $collection['type'] = 'Collection';
+        $collection['thumbnail'] = self::buildCollectionThumbnails();
         $collection['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")]'), 'value');
         $collection['items'] = self::buildCollectionItems();
 
@@ -59,6 +60,27 @@ class IIIF {
 
         return $items;
 
+    }
+
+    private function buildCollectionThumbnails ($items = []) {
+
+        foreach ($this->object as $item) {
+            $items[] = (object) [
+                /*'id' => $this->url . '/assemble/manifest/' . str_replace(':', '/', $item->pid),*/
+                'id' => $this->url . '/iiif/2/collections~islandora~object~' . $item->pid . '~datastream~TN/full/full/0/default.jpg',
+                'type' => 'Image',
+                'format' => 'image/jpeg',
+                'service' => [
+                    (object) [
+                        '@id' => $this->url . '/iiif/2/collections~islandora~object~' . $item->pid . '~datastream~TN',
+                        '@type' => "http://iiif.io/api/image/2/context.json",
+                        'profile' => 'http://iiif.io/api/image/2/level2.json'
+                    ]
+                ]
+            ];
+        }
+
+        return $items;
     }
 
     public function buildManifest ()

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -76,7 +76,12 @@ class IIIF {
                 'label' => (object) [
                     'none' => [$item->label]
                     ],
-                'thumbnail' => [self::useFedoraThumbnail($item->pid)]
+                'thumbnail' => [self::useFedoraThumbnail($item->pid)],
+                'homepage' => [
+                    self::buildHomepage($item->pid, (object) [
+                        'none' => [$item->label]
+                    ]),
+                ]
             ];
         }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -497,10 +497,11 @@ class IIIF {
         $all_collections = [];
         $collections = Request::getCollectionPidIsPartOf($this->pid, 'csv');
         $split_collections = explode("\n", $collections['body']);
-        $split_collections = array_diff( $split_collections, ['"collection"', ''] );
+        $split_collections = array_diff( $split_collections, ['"collection"', '', 'info:fedora/islandora:root'] );
         foreach ($split_collections as $collection) :
+            $just_collection_pid = str_replace('info:fedora/', '', $collection);
             $new_collection = ( object ) [
-                "id" => $this->url . '/collections/islandora/object/' . str_replace('info:fedora/', '', $collection),
+                "id" => $this->url . '/assemble/collection/' . str_replace(':', '/', $just_collection_pid),
                 "type" => "Collection"
             ];
             array_push($all_collections, $new_collection);

--- a/src/Request.php
+++ b/src/Request.php
@@ -112,6 +112,18 @@ class Request {
         return self::curlRequest($request);
 
     }
+
+    public static function getCollectionPidIsPartOf($pid, $format = 'csv') {
+
+        $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';
+
+        $query = "PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>";
+        $query .= "SELECT \$collection FROM <#ri> WHERE {{ <info:fedora/" . $pid ."> fedora-rels-ext:isMemberOfCollection \$collection . }}";
+
+        $request .= self::escapeQuery($query);
+
+        return self::curlRequest($request);
+    }
   
     public static function getBibframeDuration($pid, $dsid, $format = 'csv') {
 

--- a/src/XPath.php
+++ b/src/XPath.php
@@ -61,13 +61,18 @@ class XPath
             $values[$value] = $nodes[$key]->nodeValue;
         endforeach;
 
-        foreach ($values as $key => $value) :
-            if (!in_array($key, $attributeValues)) :
-                unset($values[$key]);
-            endif;
-        endforeach;
+        if ($values != null) {
+            foreach ($values as $key => $value) :
+                if (!in_array($key, $attributeValues)) :
+                    unset($values[$key]);
+                endif;
+            endforeach;
 
-        return array_values($values);
+            return array_values($values);
+        } else {
+            return null;
+        }
+
 
     }
 


### PR DESCRIPTION
# What Does This Do

This pull request does several things:

1. Adds thumbnails to Manifests with `"type": "Collection"` according to [IIIF Presentation v3](https://iiif.io/api/presentation/3.0/#thumbnail) and [IIIF Image 2.1.1](https://iiif.io/api/image/2.1/#technical-properties).  The properties of `thumbnail` should follow the former and the properties of `thumbnail.service` should follow the latter.
2. Adds  the `summary` property to manifest with `"type": "Collection"` with the value of `\mods\abstract` as the English value.
3. Adds a `viewingDirection` of `left-to-right` to `Collection` manifests (see [here](https://iiif.io/api/presentation/3.0/#viewingdirection) for more).
4. Adds a `behavior` of `unordered` to `Collection` manifests (see [here](https://iiif.io/api/presentation/3.0/#viewingdirection) for more).
5. Adds `partOf` property to `Collection` manifests that stores information about other IIIF collections this is a partof (see [here](https://iiif.io/api/presentation/3.0/#partof) for more).
6. Adds `partOf` property to `Manifest` manifests that stores information about other IIIF collections this is a partof (see [here](https://iiif.io/api/presentation/3.0/#partof) for more).
7. Add `metadata` property to `Collection` manifests.
8. Handles exceptions that occur due to logic of the `Publication Identifier` property when a MODS record has an `identifier` with no attributes.
9. Adds a `thumbnail` property to the brief manifests on the collection object for interoperability with bloom.
10. Only add a summary if it exists.
11. Adds a `homepage` property to the Collection manifest that is leveraged by Bloom for linking the Collection to something.  
12. Adds a `homepage` property to each individual manifest that links to the object in Islandora.
13. Adds a `homepage` property to each manifest in the `items` property on Collection manifests.  This is what bloom uses to determine what to link each thumbnail to.

# Why are we doing this?

There are two reasons:

1. The most critical reason is to get our manifests up to snuff so that they can generate metadata that is needed for Collection focused viewers like [Bloom IIIF](https://github.com/samvera-labs/bloom-iiif/).
2. This also improves quality of life for anyone who interacts with Collection manifests by taking our bare bones data and enriching it without any real knock to performance.

# What does this look like in Bloom:

![image](https://user-images.githubusercontent.com/2692416/163827241-3bb9d318-2090-4870-9b14-7e6a3204b4af.png)


# Things to ensure before merge

- [x] If summary is not null, it should now be a property on the manifest.
- [x] What happens if a collection has no MODS.
- [x] Is this an error on production still: `
<b>Notice</b>:  Trying to access array offset on value of type null in <b>/vhosts/digital/web/assemble/src/IIIF.php</b> on line <b>42</b><br />`

# Limitations

Currently, homepage properties are always linked to Islandora.  This needs to be changed for things like RFTA and RFTA Artists, but can happen later IMHO.

# Related Pull Requests

N/A