### PR TITLE
Address DIGITAL-1408: empty annotations.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -462,7 +462,10 @@ class IIIF {
         endif;
 
         $canvas->items = [self::preparePage($canvasId, $pid)];
-        $canvas->annotations = [self::prepareAnnotationPage($canvasId, $pid)];
+        $annotations = self::prepareAnnotationPage($canvasId, $pid);
+        if (count($annotations->items) > 0) {
+            $canvas->annotations = [self::prepareAnnotationPage($canvasId, $pid)];
+        }
 
         return $canvas;
 


### PR DESCRIPTION
# What Does This Do

Only adds `annotations` properties to Canvases if they exist.