### PR TITLE
Determine if the object is compound.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -702,7 +702,7 @@ class IIIF {
                 $item['type'] = "Video";
                 $item['width'] = 640;
                 $item['height'] = 360;
-                $item['duration'] = self::getBibframeDuration('MP4');
+                $item['duration'] = self::getBibframeDuration('MP4', $pid);
                 $item['format'] = "video/mp4";
             endif;
         else :

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -504,8 +504,20 @@ class IIIF {
             $this->xpath = new XPath($mods['body']);
             $this->simplexpath = new SimpleXPath($mods['body']);
             $part_metadata = self::buildMetadata();
-            if (count($part_metadata) >0) {
-                $canvas->metadata = self::buildMetadata();
+            $part_rights = self::buildRights();
+            $part_requiredstatement = self::buildRequiredStatement();
+            $summary = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
+            if (is_array($summary->en) && $summary->en[0] != "") {
+                $canvas->summary = $summary;
+            }
+            if (count($part_metadata) > 0) {
+                $canvas->metadata = $part_metadata;
+            }
+            if ($part_rights !== null) {
+                $canvas->rights = $part_rights;
+            }
+            if ($part_requiredstatement->value->en !== null ) {
+                $canvas->requiredStatement = $part_requiredstatement;
             }
         }
 

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -492,6 +492,10 @@ class IIIF {
 
             $canvas->thumbnail = self::buildThumbnail(200, 200, $data['pid']);
             $canvas->items[$key] = self::preparePage($canvasId, $data['pid'], $key, $canvasData);
+            $annotations = self::prepareAnnotationPage($canvasId, $data['pid']);
+            if (count($annotations->items) > 0) {
+                $canvas->annotations = [self::prepareAnnotationPage($canvasId, $data['pid'])];
+            }
         }
 
         return $canvas;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -26,7 +26,7 @@ class IIIF {
         $this->xpath = new XPath($mods);
         $this->simplexpath = new SimpleXPath($mods);
         $this->type = self::determineTypeByModel($model);
-
+        $this->label = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")][not(@lang)]'), 'value');
         $this->url = Utility::getBaseUrl();
 
     }
@@ -57,10 +57,18 @@ class IIIF {
     }
 
 
-    private function buildHomepage ($pid, $label) {
+    private function buildHomepage ($pid, $label_for_manifest) {
+        if(strpos($pid, 'rfta%3A') === 0) {
+            $label = str_replace('Interview with ', '', $this->label->en[0]);
+            $label = str_replace(' ', '-', $label);
+            $label = strtolower(str_replace(',', '', $label));
+            $slug = 'https://rfta.lib.utk.edu/interviews/object/' . $label;
+        } else {
+            $slug = $this->url . '/collections/islandora/object/' . $pid;
+        }
         $homepage = (object) [
-            'id' => $this->url . '/collections/islandora/object/' . $pid,
-            'label' => $label,
+            'id' => $slug,
+            'label' => $label_for_manifest,
             'type' => 'Text',
             'format' => 'text/html'
         ];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -133,7 +133,10 @@ class IIIF {
         if ($summary->en) {
             $manifest['summary'] = $summary;
         }
-        $manifest['metadata'] = self::buildMetadata();
+        $metadata = self::buildMetadata();
+        if (count($metadata) > 0) {
+            $manifest['metadata'] = $metadata;
+        }
         $rights = self::buildRights();
         if ($rights) {
             $manifest['rights'] = $rights;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -143,6 +143,9 @@ class IIIF {
         if ($this->type === 'Book') {
             $manifest['behavior'] = ["paged"];
         }
+        if ($this->type === 'Compound') {
+            $manifest['behavior'] = ["individuals"];
+        }
         if ($this->type === "Sound") {
             $manifest['accompanyingCanvas'] = self::buildAccompanyingCanvas($this->getIIIFImageURI('TN', $this->pid));
         }

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -132,10 +132,13 @@ class IIIF {
         $manifest['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
         $manifest['metadata'] = self::buildMetadata();
         $rights = self::buildRights();
-        if ($rights !== null) {
+        if ($rights) {
             $manifest['rights'] = $rights;
         }
-        $manifest['requiredStatement'] = self::buildRequiredStatement();
+        $requiredStatement = self::buildRequiredStatement();
+        if ($requiredStatement->value->en) {
+            $manifest['requiredStatement'] = $requiredStatement;
+        }
         $manifest['provider'] = self::buildProvider();
         $manifest['thumbnail'] = self::buildThumbnail(200, 200);
         $manifest['items'] = self::buildItems($id);

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -800,6 +800,8 @@ class IIIF {
             $type = "Video";
         elseif (in_array('info:fedora/islandora:bookCModel', $model)) :
             $type = "Book";
+        elseif (in_array('info:fedora/islandora:info:fedora/islandora:compoundCModel', $model)) :
+            $type = "Compound";
         else :
             $type = "Image";
         endif;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -382,7 +382,6 @@ class IIIF {
                 $items = [];
                 foreach ($canvases as $key => $canvas) {
                 $items[$key] = $this->buildCanvasWithPages($key, $uri, $canvas);
-//                    $items[$key] = $this->buildCanvas($key, $uri, $canvas);
                 }
 
                 return $items;
@@ -499,6 +498,12 @@ class IIIF {
             if (count($annotations->items) > 0) {
                 $canvas->annotations = [$annotations];
             }
+        }
+        if ($this->type === "Compound") {
+            $mods = Request::getDatastream('MODS', $data['pid']);
+            $this->xpath = new XPath($mods['body']);
+            $this->simplexpath = new SimpleXPath($mods['body']);
+            $canvas->metadata = self::buildMetadata();
         }
 
         return $canvas;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -131,7 +131,10 @@ class IIIF {
         $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")][not(@lang)]'), 'value');
         $manifest['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
         $manifest['metadata'] = self::buildMetadata();
-        $manifest['rights'] = self::buildRights();
+        $rights = self::buildRights();
+        if ($rights !== null) {
+            $manifest['rights'] = $rights;
+        }
         $manifest['requiredStatement'] = self::buildRequiredStatement();
         $manifest['provider'] = self::buildProvider();
         $manifest['thumbnail'] = self::buildThumbnail(200, 200);

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -695,7 +695,7 @@ class IIIF {
                 $item['type'] = "Sound";
                 $item['width'] = 640;
                 $item['height'] = 360;
-                $item['duration'] = self::getBibframeDuration('PROXY_MP3');
+                $item['duration'] = self::getBibframeDuration('PROXY_MP3', $pid);
                 $item['format'] = "audio/mpeg";
             elseif ($part_type == 'Video') :
                 $item['id'] = $datastream . 'MP4';
@@ -801,8 +801,11 @@ class IIIF {
 
     }
 
-    private function getBibframeDuration($dsid) {
-        $durations = Request::getBibframeDuration($this->pid, $dsid, 'csv');
+    private function getBibframeDuration($dsid, $pid="") {
+        if ($pid == "") {
+            $pid = $this->pid;
+        }
+        $durations = Request::getBibframeDuration($pid, $dsid, 'csv');
         $duration = explode("\n", $durations['body'])[1];
         $split_duration = explode(":", $duration);
         $hours = intval($split_duration[0]) *  60 * 60;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -129,7 +129,10 @@ class IIIF {
         $manifest['id'] = $id;
         $manifest['type'] = 'Manifest';
         $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")][not(@lang)]'), 'value');
-        $manifest['summary'] = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
+        $summary = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');
+        if ($summary->en) {
+            $manifest['summary'] = $summary;
+        }
         $manifest['metadata'] = self::buildMetadata();
         $rights = self::buildRights();
         if ($rights) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -494,7 +494,7 @@ class IIIF {
             $canvas->items[$key] = self::preparePage($canvasId, $data['pid'], $key, $canvasData);
             $annotations = self::prepareAnnotationPage($canvasId, $data['pid']);
             if (count($annotations->items) > 0) {
-                $canvas->annotations = [self::prepareAnnotationPage($canvasId, $data['pid'])];
+                $canvas->annotations = [$annotations];
             }
         }
 
@@ -551,8 +551,8 @@ class IIIF {
 
     }
 
-    private function getTranscipts($pagenumber, $target) {
-        $datastreams = $this::getDatastreamIds();
+    private function getTranscipts($pagenumber, $target, $pid) {
+        $datastreams = $this::getDatastreamIds($pid);
         $transcripts = [];
         if (in_array('TRANSCRIPT', $datastreams)) :
             array_push($transcripts, $this::buildTranscript('en', $pagenumber, $target));
@@ -606,7 +606,7 @@ class IIIF {
         $page = $target . '/page/annotation';
         $items = [];
         if (in_array($this->type, ['Sound', 'Video', 'Compound'])) :
-            $transcripts = self::getTranscipts($page, $target);
+            $transcripts = self::getTranscipts($page, $target, $pid);
             foreach ($transcripts as &$transcript) :
                 array_push($items, $transcript);
             endforeach;
@@ -646,8 +646,11 @@ class IIIF {
 
     }
 
-    private function getDatastreamIds () {
-        $dsids = Request::getDatastreams($this->pid, 'csv');
+    private function getDatastreamIds ($pid="") {
+        if($pid == "") {
+            $pid = $this->pid;
+        }
+        $dsids = Request::getDatastreams($pid, 'csv');
         $final_dsids = [];
         foreach (explode("\n", $dsids['body']) as &$dsid) :
             $potential_dsid = explode("/", $dsid);

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -502,8 +502,11 @@ class IIIF {
 
     }
 
-    private function buildTranscript($language_code, $page, $target) {
-        $datastream = $this->url . '/collections/islandora/object/' . $this->pid . '/datastream/';
+    private function buildTranscript($language_code, $page, $target, $pid="") {
+        if($pid == "") {
+            $pid = $this->pid;
+        }
+        $datastream = $this->url . '/collections/islandora/object/' . $pid . '/datastream/';
         if ($language_code == "es") :
             $transcript_datastream = "TRANSCRIPT-ES";
             $transcript_label = "Subtítulos en español";
@@ -514,7 +517,7 @@ class IIIF {
             $transcript_language = "en";
         endif;
         return (object) [
-                "id" => $page . '/' . $this->pid . '/' . uniqid(),
+                "id" => $page . '/' . $pid . '/' . uniqid(),
                 "type" => 'Annotation',
                 "motivation" => "supplementing",
                 "body" =>
@@ -555,10 +558,10 @@ class IIIF {
         $datastreams = $this::getDatastreamIds($pid);
         $transcripts = [];
         if (in_array('TRANSCRIPT', $datastreams)) :
-            array_push($transcripts, $this::buildTranscript('en', $pagenumber, $target));
+            array_push($transcripts, $this::buildTranscript('en', $pagenumber, $target, $pid));
         endif;
         if (in_array('TRANSCRIPT-ES', $datastreams)) :
-            array_push($transcripts, $this::buildTranscript('es', $pagenumber, $target));
+            array_push($transcripts, $this::buildTranscript('es', $pagenumber, $target, $pid));
         endif;
         return $transcripts;
     }

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -503,7 +503,10 @@ class IIIF {
             $mods = Request::getDatastream('MODS', $data['pid']);
             $this->xpath = new XPath($mods['body']);
             $this->simplexpath = new SimpleXPath($mods['body']);
-            $canvas->metadata = self::buildMetadata();
+            $part_metadata = self::buildMetadata();
+            if (count($part_metadata) >0) {
+                $canvas->metadata = self::buildMetadata();
+            }
         }
 
         return $canvas;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -605,7 +605,7 @@ class IIIF {
     private function prepareAnnotationPage ($target, $pid, $number = 1) {
         $page = $target . '/page/annotation';
         $items = [];
-        if (in_array($this->type, ['Sound', 'Video'])) :
+        if (in_array($this->type, ['Sound', 'Video', 'Compound'])) :
             $transcripts = self::getTranscipts($page, $target);
             foreach ($transcripts as &$transcript) :
                 array_push($items, $transcript);

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -659,7 +659,7 @@ class IIIF {
 
         $datastream = $this->url . '/collections/islandora/object/' . $pid . '/datastream/';
 
-        if (in_array($this->type, ['Image', 'Book'])) :
+        if (in_array($this->type, ['Image', 'Book', 'Compound'])) :
             $iiifImage = self::getIIIFImageURI('JP2', $pid);
             $item = self::getItemBody($iiifImage, $datastream . 'OBJ');
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -105,6 +105,20 @@ class Request {
 
     }
 
+    public static function getCompoundParts($pid, $format = 'csv') {
+        $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';
+        $escaped_pid = str_replace(':', "_", $pid);
+        $query = "PREFIX fedora-model: <info:fedora/fedora-system:def/model#> PREFIX fedora-rels-ext: ";
+        $query .= "<info:fedora/fedora-system:def/relations-external#> PREFIX isl-rels-ext: ";
+        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$part \$numbers \$title FROM <#ri> WHERE {{ \$part ";
+        $query .= "fedora-rels-ext:isMemberOf <info:fedora/" . $pid ."> ; isl-rels-ext:isisSequenceNumberOf" . $escaped_pid . "\$numbers ;";
+        $query .= "fedora-model:label \$title . }}";
+
+        $request .= self::escapeQuery($query);
+
+        return self::curlRequest($request);
+    }
+
     public static function getCollectionItems($pid, $format = 'csv') {
 
         $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';

--- a/src/Request.php
+++ b/src/Request.php
@@ -107,11 +107,11 @@ class Request {
 
     public static function getCompoundParts($pid, $format = 'csv') {
         $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';
-        $escaped_pid = str_replace(':', "_", $pid);
+        $escaped_pid = str_replace('%3A', "%5F", $pid);
         $query = "PREFIX fedora-model: <info:fedora/fedora-system:def/model#> PREFIX fedora-rels-ext: ";
         $query .= "<info:fedora/fedora-system:def/relations-external#> PREFIX isl-rels-ext: ";
         $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$part \$numbers \$title FROM <#ri> WHERE {{ \$part ";
-        $query .= "fedora-rels-ext:isMemberOf <info:fedora/" . $pid ."> ; isl-rels-ext:isisSequenceNumberOf" . $escaped_pid . "\$numbers ;";
+        $query .= "fedora-rels-ext:isConstituentOf <info:fedora/" . $pid ."> ; isl-rels-ext:isSequenceNumberOf" . $escaped_pid . " \$numbers ;";
         $query .= "fedora-model:label \$title . }}";
 
         $request .= self::escapeQuery($query);

--- a/src/Request.php
+++ b/src/Request.php
@@ -105,14 +105,18 @@ class Request {
 
     }
 
+    public static function getConentModel($pid, $format = 'csv') {
+
+    }
+
     public static function getCompoundParts($pid, $format = 'csv') {
         $request = $_ENV['FEDORA_URL'] . '/risearch?type=tuples&lang=sparql&format=' . $format .'&query=';
         $escaped_pid = str_replace('%3A', "%5F", $pid);
         $query = "PREFIX fedora-model: <info:fedora/fedora-system:def/model#> PREFIX fedora-rels-ext: ";
         $query .= "<info:fedora/fedora-system:def/relations-external#> PREFIX isl-rels-ext: ";
-        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$part \$numbers \$title FROM <#ri> WHERE {{ \$part ";
+        $query .= "<http://islandora.ca/ontology/relsext#> SELECT \$part \$numbers \$title \$model FROM <#ri> WHERE {{ \$part ";
         $query .= "fedora-rels-ext:isConstituentOf <info:fedora/" . $pid ."> ; isl-rels-ext:isSequenceNumberOf" . $escaped_pid . " \$numbers ;";
-        $query .= "fedora-model:label \$title . }}";
+        $query .= "fedora-model:label \$title ; fedora-model:hasModel \$model  . }}";
 
         $request .= self::escapeQuery($query);
 

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -55,10 +55,13 @@ class Utility {
         $index = [];
 
         foreach ($result as $string) {
-            $item = explode(',', $string);
-            $pageNumber = $item[1];
-            $index[$pageNumber]['pid'] = str_replace('info:fedora/', '', $item[0]);
-            $index[$pageNumber]['title'] = $item[2];
+            if (strpos($string, "info:fedora/fedora-system:FedoraObject-3.0") !== true) {
+                $item = explode(',', $string);
+                $pageNumber = $item[1];
+                $index[$pageNumber]['pid'] = str_replace('info:fedora/', '', $item[0]);
+                $index[$pageNumber]['title'] = $item[2];
+                $index[$pageNumber]['type'] = $item[3];
+            }
         }
 
         ksort($index);


### PR DESCRIPTION
# What Does This Do

- [x] Addresses [DIGITAL-1393](https://jirautk.atlassian.net/browse/DIGITAL-1393):  Make Assemble Decipher a Compound Object
- [x] Addresses [DIGITAL-1411](https://jirautk.atlassian.net/browse/DIGITAL-1411): If summary empty, should not be on manifest.
- [x] Addresses [DIGITAL-1412](https://jirautk.atlassian.net/browse/DIGITAL-1412): If no requiredStatement on metadata, do not add.
- [x] Addresses [DIGITAL-1413](https://jirautk.atlassian.net/browse/DIGITAL-1413): If no rights on metadata, do not add.
- [x] Addresses [DIGITAL-1414](https://jirautk.atlassian.net/browse/DIGITAL-1414): If no metadata on manifest, do not add.
- [x] Drops unused methods.
- [x] Adds request to get compound objects and their parts.
- [x] Makes compound objects have the `behavior` of `individuals`. See more [here](https://iiif.io/api/presentation/3.0/#behavior).
- [x] Adds metadata to canvases if the manifest describes a compound object and the associated part has IIIF metadata.
- [x] If the object is from RFTA, point its homepage at the object in rfta. 

# What Should We Be Wary Of?

What is this change's affects on:

- [x] Large Image
- [x] Video
- [x] Audio
- [x] Book
- [x] Compound Objects with Multiple Images
- [x] Compound Objects with Mixed Media

# How Does this Look in Different Viewers

- [x] Mirador
- [x] UV
- [x] Clover

# Do we get Transcripts

- [x] Yes