### PR TITLE
Remove unused method and add navPlace extension.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -193,6 +193,10 @@ class IIIF {
         if ($requiredStatement->value->en) {
             $manifest['requiredStatement'] = $requiredStatement;
         }
+        $coordinates = self::testFornavPlace();
+        if ($coordinates) {
+            $manifest['navPlace'] =self::buildnavPlace();
+        }
         $manifest['provider'] = self::buildProvider();
         $manifest['thumbnail'] = self::buildThumbnail(200, 200);
         $manifest['items'] = self::buildItems($id);
@@ -212,6 +216,20 @@ class IIIF {
         $presentation = self::buildStructures($manifest, $id);
         return json_encode($presentation);
 
+    }
+
+    private function testFornavPlace() {
+        return $this->xpath->query('subject/cartographics/coordinates');
+    }
+
+    private function buildnavPlace() {
+        $coordinates = $this->xpath->query('subject/cartographics/coordinates');
+        $navPlace  = (object) [
+            "id" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "featurecollection/1",
+            "type" => "FeatureCollection",
+            "features" => [],
+        ];
+        return $navPlace;
     }
 
     public function buildMetadata () {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -170,7 +170,10 @@ class IIIF {
     {
         $id = $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]);
 
-        $manifest['@context'] = ['https://iiif.io/api/presentation/3/context.json'];
+        $manifest['@context'] = [
+            "http://iiif.io/api/extension/navplace/context.json",
+            'https://iiif.io/api/presentation/3/context.json'
+        ];
         $manifest['id'] = $id;
         $manifest['type'] = 'Manifest';
         $manifest['label'] = self::getLanguageArray($this->xpath->query('titleInfo[not(@type="alternative")][not(@lang)]'), 'value');
@@ -241,28 +244,6 @@ class IIIF {
         );
         $metadata_with_names = $this->add_names_to_metadata($metadata);
         return self::validateMetadata($metadata_with_names);
-    }
-
-    private function add_rights_metadata($metadata_fields) {
-        $rights_uri = $this->buildRights();
-        $rights_data = new Rights($rights_uri);
-        $complete_value = "";
-        if ($rights_data->data) {
-            if (isset($rights_data->data->badge)) {
-                $rights_metadata = '<span><a href="' . str_replace('rdf', '', $rights_uri) . '"><img src="' . $rights_data->data->badge . '"/></a></span>';
-                $complete_value = $complete_value . $rights_metadata;
-            }
-            if (isset($rights_data->data->definition)) {
-                $rights_usage = '<span><a href="' . $rights_uri . '">' . $rights_data->data->label . '</a>:  ' . $rights_data->data->definition . '</span>';
-                $complete_value = $complete_value . $rights_usage;
-            }
-            elseif (isset($rights_data->data->label)) {
-                $cc_label = '<span><a href="' . $rights_data->data->uri . '"/>' . $rights_data->data->label . '</a></span>';
-                $complete_value = $complete_value . $cc_label;
-            }
-            $metadata_fields['Rights'] = [ $complete_value ];
-        }
-        return $metadata_fields;
     }
 
     private function browse_sanitize($value) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -231,18 +231,20 @@ class IIIF {
         ];
         $i = 1;
         foreach ($coordinates as $thing) {
-//            if (array_key_exists($thing, $sanitize)) {
-//                array_push($finals, $sanitize[$thing]);
-//            }
-//            else {
-//                array_push($finals, $thing);
-//            }
             $new_coordinates = explode(",", $thing);
             $longitude = $new_coordinates[1];
             $latitude = $new_coordinates[0];
             $feature = (object) [
                 "id" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/feature/" . $i,
                 "type" => "Feature",
+                "properties" => (object) [
+                    "label" => (object) [
+                        "en" => [
+                            "Temporary Property Name"
+                        ]
+                    ],
+                    "manifest" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"])
+                ],
                 "geometry" => (object) [
                     "type" => "Point",
                     "coordinates" => [

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -224,6 +224,7 @@ class IIIF {
 
     private function buildnavPlace() {
         $coordinates = $this->xpath->query('subject/cartographics/coordinates');
+        $geographic = $this->xpath->query('subject[@authority="geonames"]/geographic');
         $navPlace  = (object) [
             "id" => str_replace('digital.lib', 'iiif.lib', $this->url) . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/featurecollection/1",
             "type" => "FeatureCollection",
@@ -240,7 +241,7 @@ class IIIF {
                 "properties" => (object) [
                     "label" => (object) [
                         "en" => [
-                            "Temporary Property Name"
+                            $geographic[$i - 1]
                         ]
                     ],
                     "manifest" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"])

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -225,7 +225,7 @@ class IIIF {
     private function buildnavPlace() {
         $coordinates = $this->xpath->query('subject/cartographics/coordinates');
         $navPlace  = (object) [
-            "id" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/featurecollection/1",
+            "id" => str_replace('digital.lib', 'iiif.lib', $this->url) . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/featurecollection/1",
             "type" => "FeatureCollection",
             "features" => [],
         ];
@@ -235,7 +235,7 @@ class IIIF {
             $longitude = $new_coordinates[1];
             $latitude = $new_coordinates[0];
             $feature = (object) [
-                "id" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/feature/" . $i,
+                "id" => str_replace('digital.lib', 'iiif.lib', $this->url) . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/feature/" . $i,
                 "type" => "Feature",
                 "properties" => (object) [
                     "label" => (object) [

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -225,10 +225,35 @@ class IIIF {
     private function buildnavPlace() {
         $coordinates = $this->xpath->query('subject/cartographics/coordinates');
         $navPlace  = (object) [
-            "id" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "featurecollection/1",
+            "id" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/featurecollection/1",
             "type" => "FeatureCollection",
             "features" => [],
         ];
+        $i = 1;
+        foreach ($coordinates as $thing) {
+//            if (array_key_exists($thing, $sanitize)) {
+//                array_push($finals, $sanitize[$thing]);
+//            }
+//            else {
+//                array_push($finals, $thing);
+//            }
+            $new_coordinates = explode(",", $thing);
+            $longitude = $new_coordinates[1];
+            $latitude = $new_coordinates[0];
+            $feature = (object) [
+                "id" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/feature/" . $i,
+                "type" => "Feature",
+                "geometry" => (object) [
+                    "type" => "Point",
+                    "coordinates" => [
+                        floatval($longitude),
+                        floatval($latitude)
+                    ]
+                ]
+            ];
+            $i += 1;
+            array_push($navPlace->features, $feature);
+        }
         return $navPlace;
     }
 

--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -17,7 +17,7 @@ class Navplace
 
         $this->data = $mods;
         $this->url = $url;
-        $this->coordinates = $mods->query('subject/cartographics/coordinates');
+        $this->coordinates = $mods->query('subject[@authority="geonames"]/cartographics/coordinates');
         $this->geographic = $mods->query('subject[@authority="geonames"]/geographic');
         $this->underefenceable_uri = str_replace('digital.lib', 'iiif.lib', $this->url);
 

--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -10,6 +10,7 @@ class Navplace
     private $coordinates;
     private $geographic;
     private $url;
+    private $underefenceable_uri;
 
     public function __construct($mods, $url)
     {
@@ -18,6 +19,7 @@ class Navplace
         $this->url = $url;
         $this->coordinates = $mods->query('subject/cartographics/coordinates');
         $this->geographic = $mods->query('subject[@authority="geonames"]/geographic');
+        $this->underefenceable_uri = str_replace('digital.lib', 'iiif.lib', $this->url);
 
     }
 
@@ -25,9 +27,9 @@ class Navplace
         return $this->data->query('subject/cartographics/coordinates');
     }
 
-    private function initNavPlace() {
+    private function initFeatureCollection() {
         return (object) [
-            "id" => str_replace('digital.lib', 'iiif.lib', $this->url) . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/featurecollection/1",
+            "id" => $this->underefenceable_uri  . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/featurecollection/1",
             "type" => "FeatureCollection",
             "features" => [],
         ];
@@ -38,7 +40,7 @@ class Navplace
         $longitude = $new_coordinates[1];
         $latitude = $new_coordinates[0];
         return (object) [
-            "id" => str_replace('digital.lib', 'iiif.lib', $this->url) . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/feature/" . $identifier,
+            "id" => $this->underefenceable_uri . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/feature/" . $identifier,
             "type" => "Feature",
             "properties" => (object) [
                 "label" => (object) [
@@ -59,7 +61,7 @@ class Navplace
     }
 
     public function buildnavPlace() {
-        $navPlace = $this->initNavPlace();
+        $navPlace = $this->initFeatureCollection();
         $i = 1;
         foreach ($this->coordinates as $coordinate) {
             $feature = $this->buildFeature($coordinate, $i);

--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace Src;
+
+
+class Navplace
+{
+    private $data;
+    private $coordinates;
+    private $geographic;
+    private $url;
+
+    public function __construct($mods, $url)
+    {
+
+        $this->data = $mods;
+        $this->url = $url;
+        $this->coordinates = $mods->query('subject/cartographics/coordinates');
+        $this->geographic = $mods->query('subject[@authority="geonames"]/geographic');
+
+    }
+
+    public function checkFornavPlace() {
+        return $this->data->query('subject/cartographics/coordinates');
+    }
+
+    private function initNavPlace() {
+        return (object) [
+            "id" => str_replace('digital.lib', 'iiif.lib', $this->url) . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/featurecollection/1",
+            "type" => "FeatureCollection",
+            "features" => [],
+        ];
+    }
+
+    private function buildFeature ($coordinate, $identifier) {
+        $new_coordinates = explode(",", $coordinate);
+        $longitude = $new_coordinates[1];
+        $latitude = $new_coordinates[0];
+        return (object) [
+            "id" => str_replace('digital.lib', 'iiif.lib', $this->url) . str_replace('?update=1', '', $_SERVER["REQUEST_URI"]) . "/feature/" . $identifier,
+            "type" => "Feature",
+            "properties" => (object) [
+                "label" => (object) [
+                    "en" => [
+                        $this->geographic[$identifier - 1]
+                    ]
+                ],
+                "manifest" => $this->url . str_replace('?update=1', '', $_SERVER["REQUEST_URI"])
+            ],
+            "geometry" => (object) [
+                "type" => "Point",
+                "coordinates" => [
+                    floatval($longitude),
+                    floatval($latitude)
+                ]
+            ]
+        ];
+    }
+
+    public function buildnavPlace() {
+        $navPlace = $this->initNavPlace();
+        $i = 1;
+        foreach ($this->coordinates as $coordinate) {
+            $feature = $this->buildFeature($coordinate, $i);
+            $i += 1;
+            array_push($navPlace->features, $feature);
+        }
+        return $navPlace;
+    }
+
+}

--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -24,7 +24,7 @@ class Navplace
     }
 
     public function checkFornavPlace() {
-        return $this->data->query('subject/cartographics/coordinates');
+        return $this->data->query('subject[@authority="geonames"]/cartographics/coordinates');
     }
 
     private function initFeatureCollection() {


### PR DESCRIPTION
# What Does This Do

1. Initializes `navPlace` on Manifests
2. Removes unused method

# Why?

This allows us to have minimal navPlace bodies on manifests and think about how this should work in our future repository.  It also allows us to give feedback about [navPlace](https://github.com/CenterForDigitalHumanities/navplace-viewer/) and perhaps think about how we might use `navPlace` with something like nectar.

# When Does navPlace get added?

This adds `navPlace` only to manifests that have `subject[@authority="geonames"]/cartographics/coordinates values. This should probably be more open, but doing so requires more complicated code for very few use cases.

The `navPlace` prop is only placed on Manifest for now and gets a label equivalent to the matching string in the MODS record.  I don't think this ultimately should be the label, but this is how our data is currently modeled and getting this out there will hopefully help us think about this.

# What about navPlace on a Range?

I like how you think, and I want to do this, but I'd prefer to get this in first.  The way our data is modelled is going to cause some complexity, but ultimately I feel like getting this on Range is exactly what we want for when someone is looking at this at the item level.

# What about navPlace on a Collection?

This shouldn't be necessary since the manifests are referenced resources inside the Collection.

# Can I test this?

Sort of.  Just pull up utk_digital vagrant box, make sure assemble is configured, and add a MODS record like https://digital.lib.utk.edu/collections/islandora/object/rfta:8/datastream/MODS to the MODS of a sample record.  Review what's there.