### PR TITLE
Init refactor of non-dereferenceable ids.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -931,12 +931,12 @@ class IIIF {
                 $ranges[$range]['label'] = self::getLanguageArray($partType, 'label');
                 $ranges[$range]['items'][] = (object) [
                     'type' => 'Range',
-                    'id' => str_replace('digital.lib', 'iiif.lib', $uri). '/' . $range . '/' . $index,
+                    'id' => str_replace('digital.lib', 'iiif.lib', $uri) . '/' . $range . '/' . $index,
                     'label' => self::getLanguageArray($label[0]->textContent, 'label'),
                     'items' => [
                         (object) [
                             'type' => 'Canvas',
-                            'id' => $canvas . '#t=' . $startTime . ',' . $endTime
+                            'id' => str_replace('digital.lib', 'iiif.lib', $canvas) . '#t=' . $startTime . ',' . $endTime
                         ]
                     ]
                 ];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -529,7 +529,7 @@ class IIIF {
     }
 
     private function buildAccompanyingCanvas ($uri) {
-        $canvasId = $uri . '/canvas/accompanying';
+        $canvasId = str_replace('digital.lib', 'iiif.lib', $uri) . '/canvas/accompanying';
         $title = 'Accompanying canvas for ' . $this->xpath->query('titleInfo[not(@type="alternative")]')[0];
         $canvas = (object) [
             "id" => $canvasId,
@@ -557,7 +557,7 @@ class IIIF {
 
     public function buildCanvas ($index, $uri, $pid) {
 
-        $canvasId = $uri . '/canvas/' . $index;
+        $canvasId = str_replace('digital.lib', 'iiif.lib', $uri) . '/canvas/' . $index;
         $title = $this->xpath->query('titleInfo[not(@type="alternative")]')[0];
         $canvas = (object) [
                 "id" => $canvasId,
@@ -607,7 +607,7 @@ class IIIF {
     }
 
     public function buildCanvasWithPages ($index, $uri, $canvasData) {
-        $canvasId = $uri . '/canvas/' . $index;
+        $canvasId = str_replace('digital.lib', 'iiif.lib', $uri) . '/canvas/' . $index;
         $canvas = (object) [
             "id" => $canvasId,
             "type" => 'Canvas',

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -931,7 +931,7 @@ class IIIF {
                 $ranges[$range]['label'] = self::getLanguageArray($partType, 'label');
                 $ranges[$range]['items'][] = (object) [
                     'type' => 'Range',
-                    'id' => $uri . '/' . $range . '/' . $index,
+                    'id' => str_replace('digital.lib', 'iiif.lib', $uri). '/' . $range . '/' . $index,
                     'label' => self::getLanguageArray($label[0]->textContent, 'label'),
                     'items' => [
                         (object) [

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -982,7 +982,6 @@ class IIIF {
         $durations = Request::getBibframeDuration($pid, $dsid, 'csv');
         $response = explode("\n", $durations['body'])[1];
         if ($response != "") {
-            print_r($response);
             $duration = explode("\n", $durations['body'])[1];
             $split_duration = explode(":", $duration);
             $hours = intval($split_duration[0]) *  60 * 60;

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -927,7 +927,7 @@ class IIIF {
                 $range = Utility::sanitizeLabel($partType);
 
                 $ranges[$range]['type'] = 'Range';
-                $ranges[$range]['id'] = $uri . '/' . $range;
+                $ranges[$range]['id'] = str_replace('digital.lib', 'iiif.lib', $uri) . '/' . $range;
                 $ranges[$range]['label'] = self::getLanguageArray($partType, 'label');
                 $ranges[$range]['items'][] = (object) [
                     'type' => 'Range',

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -936,7 +936,7 @@ class IIIF {
                     'items' => [
                         (object) [
                             'type' => 'Canvas',
-                            'id' => str_replace('digital.lib', 'iiif.lib', $canvas) . '#t=' . $startTime . ',' . $endTime
+                            'id' => str_replace('digital.lib', 'iiif.lib', $canvas) . '/0#t=' . $startTime . ',' . $endTime
                         ]
                     ]
                 ];


### PR DESCRIPTION
## What Does This Do

1. Implements a new pattern for embedded resources in IIIF manifests 
2. Fixes a bug where update or initial generation of manifests for audio and video manifests fail
3. Fixes another bug where range canvases reference the wrong canvas

## Why Is This Necessary

In IIIF, a consuming application cannot assume a resource is embedded.  There is no property that specifies this, so a consuming application may dereference the id to see if there is additional information.  Currently, we have dereferenceable ids that do not represent the resource. This fixes that so that we can leverage navPlace viewer.

## I'm confused, can you explain more?

I wrote a whole blog post over the weekend explaining this that you can see [here](https://markpbaggett.github.io/iiif-id-property.html).

## Are you sure that 404ing the resources is right?

Yes, I took this to IIIF technical and this is the suggested practice.

## Anything else I should know?

Yes, this blocks that other draft pull request here.  We need to fix this then fix that.
