### PR TITLE
Make audio objects playable in UV4.

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -842,7 +842,7 @@ class IIIF {
             $item['width'] = 640;
             $item['height'] = 360;
             $item['duration'] = self::getBibframeDuration('PROXY_MP3');
-            $item['format'] = "audio/mpeg";
+            $item['format'] = "audio/mp3";
 
         elseif ($this->type === 'Video') :
             $item['id'] = $datastream . 'MP4';


### PR DESCRIPTION
## What Does This Do

Makes our audio things work in UV 4.

## More Information 

Universal Viewer 4 uses a very prescriptive typing library called [Vocabulary](https://github.com/IIIF-Commons/vocabulary). Universal Viewer attempts to apply the UV experience to any file type, and because of this it expects a very specific mime type for each kind of thing. Here you can see an [example of this for MP3s](https://github.com/IIIF-Commons/vocabulary/blob/7fa2004c501c69d1ceb11bb561ce80bd8ca429b4/src/index.ts#L75).  The type enum only makes UV use the HTML 5 Audio Canvas; it doesn't actually care what the mime type is.  If there was a sound file that the audio canvas couldn't play, the browser would handle that just as it would with anything else.