### PR TITLE
Convert all coordinates to navPlace.

### DIFF
--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -38,8 +38,8 @@ class Navplace
 
     private function buildFeature ($coordinate, $identifier) {
         $new_coordinates = explode(",", $coordinate);
-        $longitude = $new_coordinates[1];
-        $latitude = $new_coordinates[0];
+        $longitude = $this->convert_letter_values($new_coordinates[1]);
+        $latitude = $this->convert_letter_values($new_coordinates[0]);
         return (object) [
             "id" => str_replace('?update=1', '', $this->undereferenceable_uri ) . "/feature/" . $identifier,
             "type" => "Feature",

--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -83,7 +83,7 @@ class Navplace
         $characters_to_remove = array("S", "E", "N", "W");
         $negative_signs = array('S', 'W');
         if (in_array(substr($coordinate, -1), $negative_signs)) {
-            $coordinate = '-' . $coordinate;
+            $coordinate = '-' . str_replace(" ", "", $coordinate);
         }
         return str_replace($characters_to_remove, "", $coordinate);;
     }

--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -79,11 +79,19 @@ class Navplace
         return $featureCollection;
     }
 
+    private function convert_letter_values ($coordinate) {
+        $characters_to_remove = array("S", "E", "N", "W");
+        $negative_signs = array('S', 'W');
+        if (in_array(substr($coordinate, -1), $negative_signs)) {
+            $coordinate = '-' . $coordinate;
+        }
+        return str_replace($characters_to_remove, "", $coordinate);;
+    }
+
     private function buildRangeFeature ($coordinate, $identifier, $label) {
         $new_coordinates = explode(",", $coordinate);
-        $characters_to_remove = array("S", "E", "N", "W");
-        $longitude = str_replace($characters_to_remove, "", $new_coordinates[1]);
-        $latitude = str_replace($characters_to_remove, "", $new_coordinates[1]);
+        $longitude = $this->convert_letter_values($new_coordinates[1]);
+        $latitude = $this->convert_letter_values($new_coordinates[0]);
         return (object) [
             "id" => str_replace('?update=1', '', $this->undereferenceable_uri ) . "/feature/" . str_replace(" ", "", $identifier),
             "type" => "Feature",

--- a/src/Navplace.php
+++ b/src/Navplace.php
@@ -17,15 +17,15 @@ class Navplace
 
         $this->data = $mods;
         $this->url = $url;
-        $this->coordinates = $mods->query('subject[@authority="geonames"]/cartographics/coordinates');
-        $this->geographic = $mods->query('subject[@authority="geonames"]/geographic');
+        $this->coordinates = $mods->query('subject/cartographics/coordinates');
+        $this->geographic = $mods->query('subject/geographic');
         $this->title = $mods->query('titleInfo/title')[0];
         $this->undereferenceable_uri = str_replace('digital.lib.utk.edu', 'digital.lib.utk.edu/notdereferenceable', $this->url);
 
     }
 
     public function checkFornavPlace() {
-        return $this->data->query('subject[@authority="geonames"]/cartographics/coordinates');
+        return $this->data->query('subject/cartographics/coordinates');
     }
 
     private function initFeatureCollection($identifier="") {
@@ -81,8 +81,9 @@ class Navplace
 
     private function buildRangeFeature ($coordinate, $identifier, $label) {
         $new_coordinates = explode(",", $coordinate);
-        $longitude = $new_coordinates[1];
-        $latitude = $new_coordinates[0];
+        $characters_to_remove = array("S", "E", "N", "W");
+        $longitude = str_replace($characters_to_remove, "", $new_coordinates[1]);
+        $latitude = str_replace($characters_to_remove, "", $new_coordinates[1]);
         return (object) [
             "id" => str_replace('?update=1', '', $this->undereferenceable_uri ) . "/feature/" . str_replace(" ", "", $identifier),
             "type" => "Feature",


### PR DESCRIPTION
## What Does This Do?

Converts all coordinates regardless of authority to navPlace bodies following current conventions.  If coords contain a string, the string is dropped. If it contains 'W' or 'S', the float becomes negative.

## How can I test?

You could test on dlwork or review [here](https://rfta-reimagined-git-navplace-markpbaggett.vercel.app/map).  Note that the two Alumnus examples are there because I didn't force them to be updated?

## Why are you doing this?

We have many inaccuracies in our geospatial data.  This gives us an easy solution review that and correct.