### PR TITLE
Implement navDate and fix known validity errors on manifests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Fedora Resource Index.
 
 The path for this follows the general pattern above but with the DublinCore field and an associated value.  Some examples:
 
-- [https://digital.lib.utk.edu/assemble/metadata/contributor/Wilson,%20Danny](https://digital.lib.utk.edu/assemble/metadata/contributor/Wilson,%20Danny)
-- [https://digital.lib.utk.edu/assemble/metadata/subject/Black%20bears](https://digital.lib.utk.edu/assemble/metadata/subject/Black%20bears)
+- [https://digital.lib.utk.edu/assemble/metadata/contributor/Wilson,%20Danny](https://digital.lib.utk.edu/assemble/metadata/contributor/Wilson,+Danny)
+- [https://digital.lib.utk.edu/assemble/metadata/subject/Black%20bears](https://digital.lib.utk.edu/assemble/metadata/subject/Black+bears)
 - [https://digital.lib.utk.edu/assemble/metadata/date/1991](https://digital.lib.utk.edu/assemble/metadata/date/1991)
 
 ## Requirements

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -590,7 +590,8 @@ class IIIF {
     private function buildOCR ($pid) {
         return (object) [
             "id" => $this->url . "/collections/islandora/object/" . $pid . '/datastream/HOCR',
-            "motivation"=> "supplementing",
+            "type" => "Dataset",
+            "label" => self::getLanguageArray("HOCR", 'label', 'none'),
             "format"=> "text/vnd.hocr+html",
             "profile"=> "http://kba.cloud/hocr-spec/1.2/"
         ];

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -193,6 +193,8 @@ class IIIF {
         if ($requiredStatement->value->en) {
             $manifest['requiredStatement'] = $requiredStatement;
         }
+        $navDate = new Navdate($this->xpath);
+        $manifest['navDate'] = $navDate->format();
         $navPlace = new Navplace($this->xpath, $this->url);
         $coordinates = $navPlace->checkFornavPlace();
         if ($coordinates) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -194,7 +194,7 @@ class IIIF {
             $manifest['requiredStatement'] = $requiredStatement;
         }
         $navDate = new Navdate($this->xpath);
-        $manifest['navDate'] = $navDate->format();
+        $manifest['navDate'] = $navDate->date;
         $navPlace = new Navplace($this->xpath, $this->url);
         $coordinates = $navPlace->checkFornavPlace();
         if ($coordinates) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -194,7 +194,9 @@ class IIIF {
             $manifest['requiredStatement'] = $requiredStatement;
         }
         $navDate = new Navdate($this->xpath);
-        $manifest['navDate'] = $navDate->date;
+        if ($navDate->date !== null) {
+            $manifest['navDate'] = $navDate->date;
+        }
         $navPlace = new Navplace($this->xpath, $this->url);
         $coordinates = $navPlace->checkFornavPlace();
         if ($coordinates) {

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -6,59 +6,57 @@ use DateTime;
 
 class Navdate
 {
+    private $data;
     public function __construct($mods)
     {
         $this->data = $mods;
-        $this->date = $this->select_best_date();
+        $this->date = $this->selectBestDate();
     }
 
-    private function select_best_date()
+    private function selectBestDate()
     {
-        $date_created = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
-        $date_issued = $this->data->query('originInfo/dateIssued[@encoding="edtf"]');
-        if (is_array($date_created)) {
-            return $this->process_best_date($date_created);
-        }
-        elseif (is_array($date_issued)) {
-            return $this->process_best_date($date_issued);
-        }
-        else {
+        $dateCreated = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
+        $dateIssued = $this->data->query('originInfo/dateIssued[@encoding="edtf"]');
+
+        if (is_array($dateCreated)) {
+            return $this->processBestDate($dateCreated);
+        } elseif (is_array($dateIssued)) {
+            return $this->processBestDate($dateIssued);
+        } else {
             return null;
         }
     }
 
-    private function process_best_date($date_created)
+    private function processBestDate($dates)
     {
-        if (count($date_created) == 2) {
-            $start = $this->choose_format($date_created[0]);
-            $end = $this->choose_format($date_created[1]);
-            return $this->__get_middle_date($start, $end);
-        }
-        else {
-            return $this->choose_format($date_created[0]);
+        if (count($dates) == 2) {
+            $start = $this->chooseFormat($dates[0]);
+            $end = $this->chooseFormat($dates[1]);
+            return $this->getMiddleDate($start, $end);
+        } else {
+            return $this->chooseFormat($dates[0]);
         }
     }
 
-    private function choose_format($date) {
+    private function chooseFormat($date)
+    {
         $formats = [
             'Y',
             'Y-m',
             'Y-m-d'
         ];
-        $current_date = null;
+
         foreach ($formats as $format) {
-            $current_date = DateTime::createFromFormat($format, $date);
-            if ($current_date !== false) {
-                break;
+            $currentDate = DateTime::createFromFormat($format, $date);
+            if ($currentDate !== false) {
+                return $currentDate->format('Y-m-d\TH:i:s\Z');
             }
         }
-        if ($current_date !== false) {
-            return $current_date->format('Y-m-d\TH:i:s\Z');
-        }
-        return $current_date;
+
+        return null;
     }
 
-    private function __get_middle_date($date1, $date2)
+    private function getMiddleDate($date1, $date2)
     {
         $timestamp1 = strtotime($date1);
         $timestamp2 = strtotime($date2);

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -2,6 +2,8 @@
 
 namespace Src;
 
+use DateTime;
+
 class Navdate
 {
     public function __construct($mods)

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -16,7 +16,7 @@ class Navdate
     private function __select_best_date()
     {
         $date_created = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
-        return $date_created;
+        return reset($date_created);
     }
 
     public function format() {

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -31,8 +31,8 @@ class Navdate
 
     private function __get_middle_date($date1, $date2)
     {
-        $datetime_1 = new DateTime($date1);
-        $datetime_2 = new DateTime($date2);
+        $datetime_1 = $this->format($date1);
+        $datetime_2 = $this->format($date2);
         $interval = $datetime_1->diff($datetime_2);
         $middleDate = $datetime_1->add($interval->divide(2));
         return $middleDate->form('Y-m-d\TH:i:s');

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -31,10 +31,9 @@ class Navdate
 
     private function __get_middle_date($date1, $date2)
     {
-        $datetime_1 = $this->format($date1);
-        $datetime_2 = $this->format($date2);
-        $interval = $datetime_1->diff($datetime_2);
-        $middleDate = $datetime_1->add($interval->divide(2));
-        return $middleDate->form('Y-m-d\TH:i:s');
+        $timestamp1 = strtotime($date1);
+        $timestamp2 = strtotime($date2);
+        $middleTimestamp = ($timestamp1 + $timestamp2) / 2;
+        return date('Y-m-d\TH:i:s', $middleTimestamp);
     }
 }

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -7,7 +7,7 @@ class Navdate
     public function __construct($mods)
     {
         $this->data = $mods;
-        $this->date = $this->select_best_date();
+        $this->date = $this->__select_best_date();
     }
 
 

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Src;
+
+class Navdate
+{
+    public function __construct($mods)
+    {
+        $this->data = $mods;
+        $this->date = $this->select_best_date();
+    }
+
+
+    private function __select_best_date()
+    {
+        $date_created = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
+        return $date_created;
+    }
+
+    public function format() {
+        $dateTime = new DateTime($this->date);
+        return $dateTime->format('Y-m-d\TH:i:s');
+    }
+}

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -16,11 +16,25 @@ class Navdate
     private function __select_best_date()
     {
         $date_created = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
-        return reset($date_created);
+        if (count($date_created) == 2) {
+            return $this->__get_middle_date($date_created[0], $date_created[1]);
+        }
+        else {
+            return $this->format($date_created[0]);
+        }
     }
 
-    public function format() {
-        $dateTime = new DateTime($this->date);
+    private function format($date) {
+        $dateTime = new DateTime($date);
         return $dateTime->format('Y-m-d\TH:i:s');
+    }
+
+    private function __get_middle_date($date1, $date2)
+    {
+        $datetime_1 = new DateTime($date1);
+        $datetime_2 = new DateTime($date2);
+        $interval = $datetime_1->diff($datetime_2);
+        $middleDate = $datetime_1->add($interval->divide(2));
+        return $middleDate->form('Y-m-d\TH:i:s');
     }
 }

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -17,16 +17,33 @@ class Navdate
     {
         $date_created = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
         if (count($date_created) == 2) {
-            return $this->__get_middle_date($date_created[0], $date_created[1]);
+            $start = $this->choose_format($date_created[0]);
+            $end = $this->choose_format($date_created[1]);
+            return $this->__get_middle_date($start, $end);
         }
         else {
-            return $this->format($date_created[0]);
+            return $this->choose_format($date_created[0]);
         }
     }
 
-    private function format($date) {
-        $dateTime = new DateTime($date);
-        return $dateTime->format('Y-m-d\TH:i:s');
+    private function choose_format($date) {
+        $formats = [
+            'Y',
+            'Y-m',
+            'Y-m-d'
+        ];
+        $current_date = null;
+        foreach ($formats as $format) {
+            $current_date = DateTime::createFromFormat($format, $date);
+            if ($current_date !== false) {
+                break;
+            }
+        }
+        if ($current_date !== false) {
+            $formattedDate = $current_date->format('Y-m-d\TH:i:s');
+            return $formattedDate;
+        }
+        return $current_date;
     }
 
     private function __get_middle_date($date1, $date2)

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -27,7 +27,6 @@ class Navdate
         }
     }
 
-
     private function process_best_date($date_created)
     {
         if (count($date_created) == 2) {
@@ -54,8 +53,7 @@ class Navdate
             }
         }
         if ($current_date !== false) {
-            $formattedDate = $current_date->format('Y-m-d\TH:i:s');
-            return $formattedDate;
+            return $current_date->format('Y-m-d\TH:i:s\Z');
         }
         return $current_date;
     }
@@ -65,6 +63,6 @@ class Navdate
         $timestamp1 = strtotime($date1);
         $timestamp2 = strtotime($date2);
         $middleTimestamp = ($timestamp1 + $timestamp2) / 2;
-        return date('Y-m-d\TH:i:s', $middleTimestamp);
+        return date('Y-m-d\TH:i:s\Z', $middleTimestamp);
     }
 }

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -9,13 +9,27 @@ class Navdate
     public function __construct($mods)
     {
         $this->data = $mods;
-        $this->date = $this->__select_best_date();
+        $this->date = $this->select_best_date();
+    }
+
+    private function select_best_date()
+    {
+        $date_created = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
+        $date_issued = $this->data->query('originInfo/dateIssued[@encoding="edtf"]');
+        if (is_array($date_created)) {
+            return $this->process_best_date($date_created);
+        }
+        elseif (is_array($date_issued)) {
+            return $this->process_best_date($date_issued);
+        }
+        else {
+            return null;
+        }
     }
 
 
-    private function __select_best_date()
+    private function process_best_date($date_created)
     {
-        $date_created = $this->data->query('originInfo/dateCreated[@encoding="edtf"]');
         if (count($date_created) == 2) {
             $start = $this->choose_format($date_created[0]);
             $end = $this->choose_format($date_created[1]);

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -60,7 +60,7 @@ class Utility {
                 $pageNumber = $item[1];
                 $index[$pageNumber]['pid'] = str_replace('info:fedora/', '', $item[0]);
                 $index[$pageNumber]['title'] = $item[2];
-                $index[$pageNumber]['type'] = $item[3];
+                $index[$pageNumber]['type'] = "Image";
             }
         }
 


### PR DESCRIPTION
# What Does This Do

This pull request really 4 things:

## 1. Adds a navDate property (when appropriate)

This adds a `navDate` property to manifests where possible. This allows us to state the chronological order of manifests in a collection object so that viewers that are setup to display a timeline work as expected.

An example of what a timeline viewer might be something like one of these:

1. https://markpbaggett.github.io/kintner_collection_builder/timeline.html
2. https://exhibits.lib.utk.edu/galston/gottfried-galston

## 2. Addresses an offSet error that gets thrown on some book objects

I'm not sure why, but the SPARQL query results handled by `Utility::orderCanvases` expects a type at the fourth index value.  Looking at the rest of the code, we should be able to just declare this without the csv response. This specific method is from a very long time ago, and I'm not sure what the original author of the method was trying to accomplish.

## 3. Addresses a validity error caused by HOCR seeAlso references

It looks like a v2 example was followed when implementing this, but this change brings in line with v3.

## 4. Deprecates support for `%20` in favor of `+` to handle a 403 Forbidden exception due to Apache rewrite rules and a recent Apache update.

# Some specifics about choosing the best date

A deep dive into all descriptive metadata practices across all collections has not been done.  Instead, we look at two paths when deciding whether or not a manifest gets `navDate`:

1. `originInfo/dateCreated[@encoding="edtf"]`
2. `originInfo/dateIssued[@encoding="edtf"]`

We prefer the former, and if either xpath have matching date values with a count of 2 or 1, we take those dates.  If there are three or more, we do nothing to avoid unknown practices that could make things weird.

When we have 2 dates, we find the mid point.  If there is just 1, we take that date and make it the `navDate`.

We always covert the date to an xsd dateTime interval to keep things inline with spec and find midpoint to keep in line with the recipe:

1. [the Presentation v3 specification](https://iiif.io/api/presentation/3.0/)
2. [the Navigation by Chronology Recipe](https://iiif.io/api/cookbook/recipe/0230-navdate/)

# What about dateOther?

`dateOther` dates have been intentionally ignored due to known practices in some collections such as the [UTK MODS to RDF Mapping doc](https://utk-mods-to-rdf.readthedocs.io/en/latest/contents/4_mapping.html#id89)

# Why are you doing this?

I have a presentation in June that I'm working on and I want to build a Timeline viewer for [canopy iiif](https://canopy-iiif.vercel.app/) similar to what is found in CollectionBuilder currently, but in line with IIIF.

# Will this break anything in our current manifests?

Nope.  Things should be defensive enough that nothing happens if a prescribed result is not returned.  Also, it corrects 2 problems with our existing manifests and makes a documentation change suggesting `+` instead of `%20`.