### PR TITLE
Fix thumbnails

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -615,7 +615,8 @@ class IIIF {
                 $canvas->height = 640;
                 $canvas->width = 360;
             endif;
-            $canvas->thumbnail = self::buildThumbnail(200, 200, $data['pid'], $data['type']);
+            $canvasThumbnail = new Thumbnail($data['pid'], $data['type'], $this->url);
+            $canvas->thumbnail = $canvasThumbnail->buildResponse();
             $canvas->items[$key] = self::preparePage($canvasId, $data['pid'], $key, $canvasData);
             $annotations = self::prepareAnnotationPage($canvasId, $data['pid']);
             if (count($annotations->items) > 0) {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -417,26 +417,23 @@ class IIIF {
         }
         $items = array();
         $item = array();
-        $iiifImage = self::getIIIFImageURI('TN', $pid);
+        $iiifImage = self::getIIIFImageURI('JP2', $pid);
         $thumbnail_details = Request::get_thumbnail_details($iiifImage);
 
         if ($thumbnail_details['is_iiif']) :
-            $item['id'] = $thumbnail_details['thumbnail_uri'];
-            $item['width'] = $thumbnail_details['width'];
-            $item['height'] = $thumbnail_details['height'];
-            $item['service'] = $thumbnail_details['service'];
+            $thumbnail = new Thumbnail($pid, $this->type, $this->url);
+            $item = $thumbnail->buildResponse()[0];
         else :
             $item['id'] = $this->url . '/collections/islandora/object/' . $pid . '/datastream/' . 'TN';
             $item['width'] = $width;
             $item['height'] = $height;
+            $item['type'] = "Image";
+            $item['format'] = "image/jpeg";
         endif;
 
         if ( $this->type === "Sound" or $this->type === "Video") {
             $item['duration'] = self::getBibframeDuration(self::findProxyDatastream());
         }
-
-        $item['type'] = "Image";
-        $item['format'] = "image/jpeg";
         array_push($items, $item);
         if ( $this->type === "Video" || $model === "info:fedora/islandora:sp_videoCModel") {
             $video = array();

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -417,7 +417,12 @@ class IIIF {
         }
         $items = array();
         $item = array();
-        $iiifImage = self::getIIIFImageURI('JP2', $pid);
+        // Quick fix for Video Thumbnails
+        $preferredSource = 'JP2';
+        if ($this->type === "Sound" or $this->type === "Video") {
+            $preferredSource = 'TN';
+        }
+        $iiifImage = self::getIIIFImageURI($preferredSource, $pid);
         $thumbnail_details = Request::get_thumbnail_details($iiifImage);
 
         if ($thumbnail_details['is_iiif']) :

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -437,7 +437,7 @@ class IIIF {
         endif;
 
         if ( $this->type === "Sound" or $this->type === "Video") {
-            $item['duration'] = self::getBibframeDuration(self::findProxyDatastream());
+            $item->duration = self::getBibframeDuration(self::findProxyDatastream());
         }
         array_push($items, $item);
         if ( $this->type === "Video" || $model === "info:fedora/islandora:sp_videoCModel") {

--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -553,7 +553,6 @@ class IIIF {
                 "id" => $canvasId,
                 "type" => 'Canvas',
                 "label" => self::getLanguageArray($title, 'label', 'none'),
-                "thumbnail" => self::buildThumbnail(200, 200)
         ];
 
         if (in_array($this->type, ['Sound','Video'])) :
@@ -561,6 +560,7 @@ class IIIF {
             $canvas->height = 640;
             $canvas->width = 360;
             $canvas->duration = self::getBibframeDuration(self::findProxyDatastream());
+            $canvas->thumbnail = self::buildThumbnail(200, 200);
 
         else :
 
@@ -570,9 +570,12 @@ class IIIF {
                 $responseImageBody = json_decode(Request::responseBody($iiifImage));
                 $canvas->width = $responseImageBody->width;
                 $canvas->height = $responseImageBody->height;
+                $canvasThumbnail = new Thumbnail($pid, $this->type, $this->url);
+                $canvas->thumbnail = $canvasThumbnail->buildResponse();
             else :
                 $canvas->height = 640;
                 $canvas->width = 360;
+                $canvas->thumbnail = self::buildThumbnail(200, 200);
             endif;
 
         endif;

--- a/src/Navdate.php
+++ b/src/Navdate.php
@@ -7,6 +7,7 @@ use DateTime;
 class Navdate
 {
     private $data;
+    public $date;
     public function __construct($mods)
     {
         $this->data = $mods;

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -53,7 +53,7 @@ class Thumbnail
     {
         return [
             (object) [
-                '@id' => $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . $this->thumbnailSource . '/info.json',
+                '@id' => $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . $this->thumbnailSource,
                 '@type' => "http://iiif.io/api/image/2/context.json",
                 'profile' => 'http://iiif.io/api/image/2/level2.json'
             ]

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -22,7 +22,13 @@ class Thumbnail
     {
         switch ($this->model) {
             case 'Image':
-                return 'JP2';
+                $thumbnail_details = Request::get_thumbnail_details($this->getIiifImageUri('JP2'));
+                if ($thumbnail_details['is_iiif']){
+                    return 'JP2';
+                }
+                else {
+                    return 'TN';
+                }
             default:
                 return 'TN';
         }
@@ -62,11 +68,14 @@ class Thumbnail
         ];
     }
 
-    private function getIiifImageUri()
+    private function getIiifImageUri($dsid="")
     {
+        if ($dsid == "") {
+            $dsid = $this->thumbnailSource;
+        }
         $uri = $this->url . '/iiif/2/';
         $uri .= 'collections~islandora~object~' . $this->pid;
-        $uri .= '~datastream~' . $this->thumbnailSource;
+        $uri .= '~datastream~' . $dsid;
         $uri .= '/info.json';
         return $uri;
 

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -82,6 +82,7 @@ class Thumbnail
         $uri = $this->url . '/iiif/2/';
         $uri .= 'collections~islandora~object~' . $this->pid;
         $uri .= '~datastream~' . $dsid;
+        $uri .= '/info.json';
         return $uri;
 
     }

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -36,7 +36,7 @@ class Thumbnail
         }
         else {
             $sizes = $this->findIdealWidthAndHeight();
-            return $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . this->thumbnailSource . '/full/' . $sizes->width . ',' . $sizes->height . '/0/default.jpg';
+            return $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . $this->thumbnailSource . '/full/' . $sizes->width . ',' . $sizes->height . '/0/default.jpg';
         }
     }
 

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -14,6 +14,8 @@ class Thumbnail
         $this->model = $model;
         $this->pid = $pid;
         $this->url = $url;
+        $this->width = 200;
+        $this->height = 200;
         $this->thumbnailSource = $this->getBestThumbnail();
         $this->iiifImageUri = $this->getIiifImageUri();
     }
@@ -41,6 +43,8 @@ class Thumbnail
         }
         else {
             $sizes = $this->findIdealWidthAndHeight();
+            $this->width = intval($sizes->width);
+            $this->height = intval($sizes->height);
             return $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . $this->thumbnailSource . '/full/' . $sizes->width . ',' . $sizes->height . '/0/default.jpg';
         }
     }
@@ -61,6 +65,8 @@ class Thumbnail
         return [
             (object) [
                 'id' => $this->buildIdentifier(),
+                'width' => $this->width,
+                'height' => $this->height,
                 'type' => 'Image',
                 'format' => 'image/jpeg',
                 'service' => $this->buildService()

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -44,7 +44,7 @@ class Thumbnail
     {
         return [
             (object) [
-                '@id' => $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . this->thumbnailSource . '/info.json',
+                '@id' => $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . $this->thumbnailSource . '/info.json',
                 '@type' => "http://iiif.io/api/image/2/context.json",
                 'profile' => 'http://iiif.io/api/image/2/level2.json'
             ]

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -52,11 +52,13 @@ class Thumbnail
 
     public function buildResponse()
     {
-        return (object) [
-            'id' => $this->buildIdentifier(),
-            'type' => 'Image',
-            'format' => 'image/jpeg',
-            'service' => $this->buildService()
+        return [
+            (object) [
+                'id' => $this->buildIdentifier(),
+                'type' => 'Image',
+                'format' => 'image/jpeg',
+                'service' => $this->buildService()
+            ]
         ];
     }
 

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -23,7 +23,6 @@ class Thumbnail
         switch ($this->model) {
             case 'Image':
                 return 'JP2';
-                break;
             default:
                 return 'TN';
         }

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Src;
+
+class Thumbnail
+{
+    private $model;
+    public $pid;
+    public $thumbnailSource;
+    public $url;
+    public function __construct($pid, $model, $url)
+    {
+        $this->model = $model;
+        $this->pid = $pid;
+        $this->url = $url;
+        $this->thumbnailSouce = $this->getBestThumbnail();
+    }
+
+    private function getBestThumbnail()
+    {
+        switch ($this->model) {
+            case 'Image':
+                return 'JP2';
+                break;
+            default:
+                return 'TN';
+        }
+    }
+
+    private function buildService()
+    {
+        return [
+            (object) [
+                '@id' => $this->url . '/iiif/2/collections~islandora~object~' . $this->pid . '~datastream~' . this->thumbnailSource . '/info.json',
+                '@type' => "http://iiif.io/api/image/2/context.json",
+                'profile' => 'http://iiif.io/api/image/2/level2.json'
+            ]
+        ];
+    }
+}

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -51,7 +51,7 @@ class Thumbnail
         ];
     }
 
-    private function buildResponse()
+    public function buildResponse()
     {
         return (object) [
             'id' => $this->buildIdentifier(),

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -82,7 +82,6 @@ class Thumbnail
         $uri = $this->url . '/iiif/2/';
         $uri .= 'collections~islandora~object~' . $this->pid;
         $uri .= '~datastream~' . $dsid;
-        $uri .= '/info.json';
         return $uri;
 
     }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -89,12 +89,7 @@ class Utility {
 
         foreach ($result as $string) {
             $item = explode(',', $string);
-            if(str_starts_with($item[1], '"')) {
-                $split = explode('"', $string);
-                $label = str_replace('"', '', $split[1]);
-            } else {
-                $label = $item[1];
-            }
+            $label = str_replace('"', '', $item[1]);
             $index[] = (object) [
                 'pid' => str_replace('info:fedora/', '', $item[0]),
                 'label' => $label,


### PR DESCRIPTION
# What Does This Do

1. Initializes work to make thumbnail generation more sustainable.
2. Fixes an issue where an item with a `dc:title` that includes double quote got no label in the IIIF Collection object.
3. Makes it so that Works sourced from an image server don't use the Islandora generated thumbnail.