### PR TITLE
Metadata redux

### DIFF
--- a/src/IIIF.php
+++ b/src/IIIF.php
@@ -633,9 +633,10 @@ class IIIF {
         }
         if ($this->type === "Compound") {
             $mods = Request::getDatastream('MODS', $data['pid']);
+            $compound_metadata = new MetadataProperty($this->xpath, $this->simplexpath);
             $this->xpath = new XPath($mods['body']);
             $this->simplexpath = new SimpleXPath($mods['body']);
-            $part_metadata = self::buildMetadata();
+            $part_metadata = $compound_metadata->buildCanvas($this->xpath, $this->simplexpath);
             $part_rights = self::buildRights();
             $part_requiredstatement = self::buildRequiredStatement();
             $summary = self::getLanguageArray($this->xpath->query('abstract[not(@lang)]'), 'value');

--- a/src/MetadataProperty.php
+++ b/src/MetadataProperty.php
@@ -9,6 +9,8 @@ class MetadataProperty
 
         $this->mods = $mods;
         $this->simpleMods = $simpleMods;
+        $this->primary_metadata = self::buildManifest();
+        $this->validated_primary_metadata = self::validateMetadata($this->primary_metadata);
         
     }
 
@@ -71,41 +73,62 @@ class MetadataProperty
             'Provided by' => $this->mods->query('recordInfo/recordContentSource'),
             'Related Resource' => $final_resources,
         );
-        $metadata_with_names = $this->add_names_to_metadata($metadata);
-        return self::validateMetadata($metadata_with_names);
+        return $this->add_names_to_metadata($metadata);
     }
 
     public function buildCanvas($canvasMODS, $canvasSimpleMODS)
     {
-        $date = $this->mods->query('originInfo/dateCreated[not(@encoding)]');
+        $date = $canvasMODS->query('originInfo/dateCreated[not(@encoding)]');
         if ($date == "") {
-            $date = $this->mods->query('originInfo/dateCreated[@encoding]');
+            $date = $canvasMODS->query('originInfo/dateCreated[@encoding]');
         }
-        $related_resources = $this->mods->query('relatedItem[@type="references"]/location/url');
+        $related_resources = $canvasMODS->query('relatedItem[@type="references"]/location/url');
         $final_resources = Utility::addAnchorsToReferences($related_resources);
         $metadata = array(
-            'Alternative Title' => $this->mods->query('titleInfo[@type="alternative"]'),
-            'Table of Contents' => $this->mods->query('tableOfContents'),
-            'Publisher' => $this->mods->query('originInfo/publisher'),
+            'Canvas Label' => $canvasMODS->query('titleInfo/title'),
+            'Alternative Title' => $canvasMODS->query('titleInfo[@type="alternative"]'),
+            'Table of Contents' => $canvasMODS->query('tableOfContents'),
+            'Publisher' => $canvasMODS->query('originInfo/publisher'),
             'Date' => $date,
-            'Publication Date' => $this->mods->query('originInfo/dateIssued[not(@encoding)]'),
-            'Format' => $this->mods->query('physicalDescription/form[not(@type="material")]'),
-            'Extent' => $this->mods->query('physicalDescription/extent'),
-            'Subject' => $this->mods->query('subject[not(@displayLabel="Narrator Class")]/topic'),
-            'Narrator Role' => $this->mods->query('subject[@displayLabel="Narrator Class"]/topic'),
-            'Place' => $this->browse_sanitize($this->mods->query('subject/geographic')),
-            'Time Period' => $this->mods->query('subject/temporal'),
-            'Description' => $this->mods->query('abstract[not(@lang)]'),
-            'Descripción' => $this->mods->query('abstract[@lang="spa"]'),
-            'Título' => $this->mods->query('titleInfo[@lang="spa"]/title'),
-            'Publication Identifier' => $this->mods->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn']),
-            'Browse' => $this->browse_sanitize($this->mods->query('note[@displayLabel="Browse"]')),
-            'Language' => $this->mods->query('language/languageTerm'),
-            'Provided by' => $this->mods->query('recordInfo/recordContentSource'),
+            'Publication Date' => $canvasMODS->query('originInfo/dateIssued[not(@encoding)]'),
+            'Format' => $canvasMODS->query('physicalDescription/form[not(@type="material")]'),
+            'Extent' => $canvasMODS->query('physicalDescription/extent'),
+            'Subject' => $canvasMODS->query('subject[not(@displayLabel="Narrator Class")]/topic'),
+            'Narrator Role' => $canvasMODS->query('subject[@displayLabel="Narrator Class"]/topic'),
+            'Place' => $this->browse_sanitize($canvasMODS->query('subject/geographic')),
+            'Time Period' => $canvasMODS->query('subject/temporal'),
+            'Description' => $canvasMODS->query('abstract[not(@lang)]'),
+            'Descripción' => $canvasMODS->query('abstract[@lang="spa"]'),
+            'Título' => $canvasMODS->query('titleInfo[@lang="spa"]/title'),
+            'Publication Identifier' => $canvasMODS->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn']),
+            'Browse' => $this->browse_sanitize($canvasMODS->query('note[@displayLabel="Browse"]')),
+            'Language' => $canvasMODS->query('language/languageTerm'),
+            'Provided by' => $canvasMODS->query('recordInfo/recordContentSource'),
             'Related Resource' => $final_resources,
         );
         $metadata_with_names = $this->add_names_to_metadata($metadata);
-        return self::validateMetadata($metadata_with_names);
+        $unique = self::compare($metadata_with_names);
+        $validated_metadata = self::validateMetadata($unique);
+        return $validated_metadata;
+    }
+
+    private function compare($canvas_data) {
+        $new_data = array();
+        foreach ($canvas_data as $key => $value) {
+            if (array_key_exists($key, $this->primary_metadata)) {
+                if ($this->primary_metadata[$key] !== null and $canvas_data[$key] !== null) {
+                    foreach($value as $piece) {
+                        if (!in_array($piece, $this->primary_metadata[$key])) {
+                            $new_data[$key] = array($piece);
+                        }
+                    }
+                }
+            }
+            else {
+                $new_data[$key] = $value;
+            }
+        }
+        return $new_data;
     }
 
     private function getLabelValuePair ($label, $value, $language="en") {

--- a/src/MetadataProperty.php
+++ b/src/MetadataProperty.php
@@ -116,10 +116,11 @@ class MetadataProperty
         $new_data = array();
         foreach ($canvas_data as $key => $value) {
             if (array_key_exists($key, $this->primary_metadata)) {
+                $new_data[$key] = array();
                 if ($this->primary_metadata[$key] !== null and $canvas_data[$key] !== null) {
                     foreach($value as $piece) {
                         if (!in_array($piece, $this->primary_metadata[$key])) {
-                            $new_data[$key] = array($piece);
+                            array_push($new_data[$key], $piece);
                         }
                     }
                 }

--- a/src/MetadataProperty.php
+++ b/src/MetadataProperty.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Src;
+
+class MetadataProperty
+{
+    public function __construct($mods, $simpleMods)
+    {
+
+        $this->mods = $mods;
+        $this->simpleMods = $simpleMods;
+        
+    }
+
+    private function add_names_to_metadata($current_metadata) {
+        $names = $this->simpleMods->get_names();
+        foreach ($names as $k => $v) {
+            $current_metadata[$k] = $v;
+        }
+        return $current_metadata;
+    }
+
+    private function browse_sanitize($value) {
+        $sanitize = array(
+            'Medical Personnel & First Responders' => 'Medical Personnel and First Responders',
+            'Educators and Public or Government officials or employees' => 'Public or Government Employees',
+            'Meterologists & Environmentalists' => 'Meterologists and Environmentalists',
+            'Disaster Response & Recovery' => 'Disaster Response and Recovery',
+            'Arrowmont School of Arts & Crafts' => 'Arrowmont School of Arts and Crafts'
+        );
+        $finals = array();
+        if($value) {
+            foreach ($value as $thing) {
+                if (array_key_exists($thing, $sanitize)) {
+                    array_push($finals, $sanitize[$thing]);
+                }
+                else {
+                    array_push($finals, $thing);
+                }
+            }
+        }
+        return $finals;
+    }
+
+    public function buildManifest()
+    {
+        $date = $this->mods->query('originInfo/dateCreated[not(@encoding)]');
+        if ($date == "") {
+            $date = $this->mods->query('originInfo/dateCreated[@encoding]');
+        }
+        $related_resources = $this->mods->query('relatedItem[@type="references"]/location/url');
+        $final_resources = Utility::addAnchorsToReferences($related_resources);
+        $metadata = array(
+            'Alternative Title' => $this->mods->query('titleInfo[@type="alternative"]'),
+            'Table of Contents' => $this->mods->query('tableOfContents'),
+            'Publisher' => $this->mods->query('originInfo/publisher'),
+            'Date' => $date,
+            'Publication Date' => $this->mods->query('originInfo/dateIssued[not(@encoding)]'),
+            'Format' => $this->mods->query('physicalDescription/form[not(@type="material")]'),
+            'Extent' => $this->mods->query('physicalDescription/extent'),
+            'Subject' => $this->mods->query('subject[not(@displayLabel="Narrator Class")]/topic'),
+            'Narrator Role' => $this->mods->query('subject[@displayLabel="Narrator Class"]/topic'),
+            'Place' => $this->browse_sanitize($this->mods->query('subject/geographic')),
+            'Time Period' => $this->mods->query('subject/temporal'),
+            'Description' => $this->mods->query('abstract[not(@lang)]'),
+            'Descripción' => $this->mods->query('abstract[@lang="spa"]'),
+            'Título' => $this->mods->query('titleInfo[@lang="spa"]/title'),
+            'Publication Identifier' => $this->mods->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn']),
+            'Browse' => $this->browse_sanitize($this->mods->query('note[@displayLabel="Browse"]')),
+            'Language' => $this->mods->query('language/languageTerm'),
+            'Provided by' => $this->mods->query('recordInfo/recordContentSource'),
+            'Related Resource' => $final_resources,
+        );
+        $metadata_with_names = $this->add_names_to_metadata($metadata);
+        return self::validateMetadata($metadata_with_names);
+    }
+
+    public function buildCanvas($canvasMODS, $canvasSimpleMODS)
+    {
+        $date = $this->mods->query('originInfo/dateCreated[not(@encoding)]');
+        if ($date == "") {
+            $date = $this->mods->query('originInfo/dateCreated[@encoding]');
+        }
+        $related_resources = $this->mods->query('relatedItem[@type="references"]/location/url');
+        $final_resources = Utility::addAnchorsToReferences($related_resources);
+        $metadata = array(
+            'Alternative Title' => $this->mods->query('titleInfo[@type="alternative"]'),
+            'Table of Contents' => $this->mods->query('tableOfContents'),
+            'Publisher' => $this->mods->query('originInfo/publisher'),
+            'Date' => $date,
+            'Publication Date' => $this->mods->query('originInfo/dateIssued[not(@encoding)]'),
+            'Format' => $this->mods->query('physicalDescription/form[not(@type="material")]'),
+            'Extent' => $this->mods->query('physicalDescription/extent'),
+            'Subject' => $this->mods->query('subject[not(@displayLabel="Narrator Class")]/topic'),
+            'Narrator Role' => $this->mods->query('subject[@displayLabel="Narrator Class"]/topic'),
+            'Place' => $this->browse_sanitize($this->mods->query('subject/geographic')),
+            'Time Period' => $this->mods->query('subject/temporal'),
+            'Description' => $this->mods->query('abstract[not(@lang)]'),
+            'Descripción' => $this->mods->query('abstract[@lang="spa"]'),
+            'Título' => $this->mods->query('titleInfo[@lang="spa"]/title'),
+            'Publication Identifier' => $this->mods->queryFilterByAttribute('identifier', false, 'type', ['issn','isbn']),
+            'Browse' => $this->browse_sanitize($this->mods->query('note[@displayLabel="Browse"]')),
+            'Language' => $this->mods->query('language/languageTerm'),
+            'Provided by' => $this->mods->query('recordInfo/recordContentSource'),
+            'Related Resource' => $final_resources,
+        );
+        $metadata_with_names = $this->add_names_to_metadata($metadata);
+        return self::validateMetadata($metadata_with_names);
+    }
+
+    private function getLabelValuePair ($label, $value, $language="en") {
+
+        if ($value !== null) {
+            return (object) [
+                'label' => self::getLanguageArray($label, 'label', $language),
+                'value' => self::getLanguageArray($value, 'value', $language)
+            ];
+        } else {
+            return null;
+
+        }
+
+    }
+
+    private function getLanguageArray ($string, $type, $language = 'en') {
+
+        if ($type === 'label') :
+            $string = [$string];
+        endif;
+
+        return (object) [
+            $language => $string
+        ];
+
+    }
+
+    private function validateMetadata ($array) {
+
+        $sets = array();
+        $spanish_labels = array('spa_sample_1', 'spa_sample_2');
+
+        foreach ($array as $label => $value) :
+            if ($value !== null and empty($value) !== true) :
+                if (in_array($label, $spanish_labels)) :
+                    $lang = 'es';
+                else :
+                    $lang = 'en';
+                endif;
+                $sets[] = self::getLabelValuePair(
+                    $label,
+                    $value,
+                    $lang
+                );
+            endif;
+        endforeach;
+
+        return $sets;
+
+    }
+
+}

--- a/src/Rights.php
+++ b/src/Rights.php
@@ -125,7 +125,11 @@ class Rights {
         if( isset($rights_values->$uri) ) {
             return $rights_values->$uri;
         }
-        elseif (str_contains($uri, 'creativecommons')){
+        elseif(gettype($this->uri) == Null) {
+            $cne_uri = "http://rightsstatements.org/vocab/CNE/1.0/";
+            return $rights_values->$cne_uri;
+        }
+        elseif (strpos($uri, 'creativecommons')){
             $creative_commons_uri = str_replace("rdf", "", $uri);
             $creative_commons_uri = str_replace("https", "http", $creative_commons_uri);
             $xml = Request::getCreativeCommons($creative_commons_uri);
@@ -145,7 +149,8 @@ class Rights {
             ];
         }
         else {
-            return null;
+            $cne_uri = "http://rightsstatements.org/vocab/CNE/1.0/";
+            return $rights_values->$cne_uri;
         }
 
     }


### PR DESCRIPTION
# What Does This Do

1. Refactors descriptive metadata into its own class.
2. Makes canvases only include descriptive metadata that is not found in the parent.
3. Fixes an old bug where rights work was written around PHP 8.
4. Writes CNE for any works without rights.