### PR TITLE
403 apache rewrite

### DIFF
--- a/manifest/.htaccess
+++ b/manifest/.htaccess
@@ -1,4 +1,4 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteRule ^(.*)$ index.php?url=/$1 [QSA,B, L]
+    RewriteRule ^(.*)$ index.php?url=/$1 [QSA, B, L]
 </IfModule>

--- a/manifest/.htaccess
+++ b/manifest/.htaccess
@@ -1,4 +1,4 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteRule ^(.*)$ index.php?url=/$1 [QSA,L]
+    RewriteRule ^(.*)$ index.php?url=/$1 [QSA,B, L]
 </IfModule>

--- a/metadata/.htaccess
+++ b/metadata/.htaccess
@@ -1,4 +1,4 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteRule ^(.*)$ index.php?url=/$1 [QSA,L]
+    RewriteRule ^(.*)$ index.php?url=/$1 [QSA, B, L]
 </IfModule>


### PR DESCRIPTION
# What Does This Do

Ensure that strings (formatted and unformatted) don't cause a ` AH10411: Rewritten query string contains control characters or spaces` error on request.